### PR TITLE
Use LemMinX 0.26.1

### DIFF
--- a/org.eclipse.wildwebdeveloper.xml/pom.xml
+++ b/org.eclipse.wildwebdeveloper.xml/pom.xml
@@ -40,7 +40,7 @@
 									<groupId>org.eclipse.lemminx</groupId>
 									<artifactId>org.eclipse.lemminx</artifactId>
 									<!-- Bumping to version with API breakage needs to bump bundle version at least by +0.1.0 -->
-									<version>0.26.0</version>
+									<version>0.26.1</version>
 									<!-- classifier:uber includes all dependencies -->
 									<classifier>uber</classifier>
 								</artifactItem>


### PR DESCRIPTION
LemMinX 0.26.1/0.26.0 is not API-compatible with 0.25 so extensions may not work properly.