### PR TITLE
Fix #1290 - No grammar provided for <vue.sfc.style.variable.injections>

### DIFF
--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -764,7 +764,7 @@
       </grammar>
       <grammar
             path="grammars/vue/vue-sfc-style-variable-injection.json"
-            scopeName="vue.sfc.style.variable.injections">
+            scopeName="vue.sfc.style.variable.injection">
       </grammar>
 
    </extension>


### PR DESCRIPTION
Typo inside scopeName