### PR TITLE
Allow using TypeScript version specified by project

### DIFF
--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -657,6 +657,15 @@
    </extension>
 
    <extension
+         id="JSTSPreferenceInitializer"
+         name="JSTSPreferenceInitializer"
+         point="org.eclipse.core.runtime.preferences">
+      <initializer
+            class="org.eclipse.wildwebdeveloper.jsts.ui.preferences.JSTSPreferenceInitializer">
+      </initializer>
+   </extension>
+
+   <extension
          id="JavaScriptPreferenceInitializer"
          name="JavaScriptPreferenceInitializer"
          point="org.eclipse.core.runtime.preferences">

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/JSTSLanguageServer.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/JSTSLanguageServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Red Hat Inc. and others.
+ * Copyright (c) 2016-2023 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,8 +10,12 @@
  * Contributors:
  *   Mickael Istria (Red Hat Inc.) - initial implementation
  *   Andrew Obuchowicz (Red Hat Inc.) - Add ESLint support
+ *   Pierre-Yves Bigourdan - Allow using TypeScript version specified by project
  *******************************************************************************/
 package org.eclipse.wildwebdeveloper.jsts;
+
+import static org.eclipse.wildwebdeveloper.jsts.ui.preferences.JSTSPreferenceServerConstants.TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_PROJECT;
+import static org.eclipse.wildwebdeveloper.jsts.ui.preferences.JSTSPreferenceServerConstants.getTypeScriptVersion;
 
 import java.io.File;
 import java.io.IOException;
@@ -77,10 +81,13 @@ public class JSTSLanguageServer extends ProcessStreamConnectionProviderWithPrefe
 			plugins.add(new TypeScriptPlugin("typescript-lit-html-plugin"));
 			options.put("plugins", plugins.stream().map(TypeScriptPlugin::toMap).toArray());
 			
-			// Initialize tsserver path
-			Map<String, String> tsServer = new HashMap<>();
-			tsServer.put("path", tsserverPath);
-			options.put("tsserver", tsServer);
+			// If the tsserver path is not explicitly specified, tsserver will use the local
+			// TypeScript version installed as part of the project's dependencies, if found.
+			if (!TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_PROJECT.equals(getTypeScriptVersion())) {
+				Map<String, String> tsServer = new HashMap<>();
+				tsServer.put("path", tsserverPath);
+				options.put("tsserver", tsServer);
+			}
 		} catch (IOException e) {
 			Activator.getDefault().getLog().log(
 					new Status(IStatus.ERROR, Activator.getDefault().getBundle().getSymbolicName(), e.getMessage(), e));

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/Messages.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Red Hat Inc. and others.
+ * Copyright (c) 2022-2023 Red Hat Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *  Angelo ZERR (Red Hat Inc.) - initial implementation
+ *  Pierre-Yves Bigourdan - Allow using TypeScript version specified by project
  *******************************************************************************/
 package org.eclipse.wildwebdeveloper.jsts.ui;
 
@@ -18,6 +19,10 @@ import org.eclipse.osgi.util.NLS;
  *
  */
 public class Messages extends NLS {
+
+	public static String JSTSPreferencePage_typeScriptVersion;
+	public static String JSTSPreferencePage_typeScriptVersion_eclipse;
+	public static String JSTSPreferencePage_typeScriptVersion_project;
 
 	// --------- TypeScript Inlay Hints preference page
 	public static String TypeScriptInlayHintPreferencePage_showInlayHintsFor_label;

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/messages.properties
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/messages.properties
@@ -1,5 +1,5 @@
 #/*******************************************************************************
-# * Copyright (c) 2022 Red Hat Inc. and others.
+# * Copyright (c) 2022-2023 Red Hat Inc. and others.
 # * This program and the accompanying materials are made
 # * available under the terms of the Eclipse Public License 2.0
 # * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,7 +8,13 @@
 # *
 # * Contributors:
 # *  Angelo ZERR (Red Hat Inc.) - initial implementation
+# *  Pierre-Yves Bigourdan - Allow using TypeScript version specified by project
 # *******************************************************************************/
+
+JSTSPreferencePage_typeScriptVersion=Typescript version used for JavaScript and TypeScript language features:
+JSTSPreferencePage_typeScriptVersion_eclipse=Eclipse version
+JSTSPreferencePage_typeScriptVersion_project=Project version
+
 
 # TypeScript Inlay Hints preference page
 TypeScriptInlayHintPreferencePage_showInlayHintsFor_label=Show inlay hints for:

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/preferences/JSTSPreferenceInitializer.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/preferences/JSTSPreferenceInitializer.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Pierre-Yves Bigourdan - initial implementation
+ *******************************************************************************/
+package org.eclipse.wildwebdeveloper.jsts.ui.preferences;
+
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+
+/**
+ * JS/TS preference initializer.
+ *
+ */
+public class JSTSPreferenceInitializer extends AbstractPreferenceInitializer {
+
+	@Override
+	public void initializeDefaultPreferences() {
+		JSTSPreferenceServerConstants.initializeDefaultPreferences();
+	}
+
+}

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/preferences/JSTSPreferencePage.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/preferences/JSTSPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Red Hat Inc. and others.
+ * Copyright (c) 2022-2023 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,10 +12,17 @@
  *******************************************************************************/
 package org.eclipse.wildwebdeveloper.jsts.ui.preferences;
 
+import static org.eclipse.wildwebdeveloper.jsts.ui.preferences.JSTSPreferenceServerConstants.TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION;
+import static org.eclipse.wildwebdeveloper.jsts.ui.preferences.JSTSPreferenceServerConstants.TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_ECLIPSE;
+import static org.eclipse.wildwebdeveloper.jsts.ui.preferences.JSTSPreferenceServerConstants.TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_PROJECT;
+
+import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.wildwebdeveloper.Activator;
+import org.eclipse.wildwebdeveloper.jsts.ui.Messages;
 
 /**
  * JS/TS main preference page.
@@ -34,5 +41,14 @@ public class JSTSPreferencePage extends FieldEditorPreferencePage implements IWo
 
 	@Override
 	protected void createFieldEditors() {
+		Composite parent = getFieldEditorParent();
+		addField(new ComboFieldEditor(TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION,
+				Messages.JSTSPreferencePage_typeScriptVersion,
+				new String[][] {
+						{ Messages.JSTSPreferencePage_typeScriptVersion_eclipse,
+								TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_ECLIPSE },
+						{ Messages.JSTSPreferencePage_typeScriptVersion_project,
+								TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_PROJECT } },
+				parent));
 	}
 }

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/preferences/JSTSPreferenceServerConstants.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/preferences/JSTSPreferenceServerConstants.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Pierre-Yves Bigourdan - initial implementation
+ *******************************************************************************/
+package org.eclipse.wildwebdeveloper.jsts.ui.preferences;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.wildwebdeveloper.Activator;
+
+/**
+ * JS/TS preference server constants.
+ *
+ */
+public class JSTSPreferenceServerConstants {
+
+	public static final String TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION = "typescript.tsserver.typescript.version";
+
+	public static final String TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_ECLIPSE = "Eclipse version";
+	public static final String TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_PROJECT = "Project version";
+
+	public static String getTypeScriptVersion() {
+		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
+		return store.getString(TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION);
+	}
+
+	public static void initializeDefaultPreferences() {
+		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
+		store.setDefault(TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION, TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_ECLIPSE);
+	}
+}


### PR DESCRIPTION
Until now, the TypeScript version was systematically being overridden to point to the one packaged with Eclipse. This meant that if your project relied on a different version of TypeScript (as specified in `package.json` for example), there was a risk of incompatibilities. Even worse, custom type definitions brought in third party dependencies were not resolved properly, for example in the case of React.js:
<img width="575" alt="Screenshot 2023-08-14 at 12 17 04" src="https://github.com/eclipse-wildwebdeveloper/wildwebdeveloper/assets/10694593/9743803f-4f3b-4a88-b480-fbad33bfb793">

VSCode allows switching between either its own version of TypeScript, or the one specified by the project, as described here:
https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript

This PR adds similar support to Eclipse, via a preference page option. The default is the same as before, i.e. TypeScript packaged with Eclipse, so the behaviour for current Eclipse users will not change.

Tested on a project locally, all type definition resolution errors go away, and you can see the version that is being picked up by referring to the log messages produced by the language server at startup (as documented [here](https://github.com/typescript-language-server/typescript-language-server#typescript-version-notification)).

With the Eclipse version:
```
Typescript Server version info: {version=5.0.4, source=user-setting}
```

With the Project version:
```
Typescript Server version info: {version=5.0.2-sdk, source=workspace}
```