### PR TITLE
Add snakeyaml dependency to wildwebdeveloper repository

### DIFF
--- a/repository/category.xml
+++ b/repository/category.xml
@@ -78,6 +78,9 @@
    <bundle id="org.eclipse.wildwebdeveloper.product.branding" version="0.0.0">
       <category name="Dependencies"/>
    </bundle>
+   <bundle id="org.yaml.snakeyaml">
+      <category name="Dependencies"/>
+   </bundle>
    <category-def name="Wild Web Developer" label="Eclipse Wild Web Developer - Web Dev in Eclipse IDE"/>
    <category-def name="Dependencies" label="Transitive Dependencies (no need to install directly)"/>
    <category-def name="Sources" label="Sources and Tests (for integrators)"/>


### PR DESCRIPTION
This avoids the need to add to sankeyaml in downstream consumer (e.g. m2e) via Orbit, if they don't use the SimRel repo (which I was told is not recommended).