### PR TITLE
#1327 A "Chrome Debug" session can now be started even when a chrome window is already open

### DIFF
--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/chrome/ChromeRunDAPDebugDelegate.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/chrome/ChromeRunDAPDebugDelegate.java
@@ -40,8 +40,6 @@ import org.eclipse.ui.internal.browser.IBrowserDescriptor;
 import org.eclipse.wildwebdeveloper.Activator;
 import org.eclipse.wildwebdeveloper.debug.AbstractHTMLDebugDelegate;
 import org.eclipse.wildwebdeveloper.debug.LaunchConstants;
-import org.eclipse.wildwebdeveloper.debug.MessageUtils;
-import org.eclipse.wildwebdeveloper.debug.Messages;
 
 import com.google.gson.JsonObject;
 
@@ -54,6 +52,10 @@ public class ChromeRunDAPDebugDelegate extends AbstractHTMLDebugDelegate {
 	public static final String RUNTIME_EXECUTABLE = "runtimeExecutable";
 	public static final String URL = "url";
 	private static final String SOURCE_MAPS = "sourceMaps";
+	public static final String TYPE = "type";
+	public static final String CHROME = "chrome";
+	public static final String REQUEST = "request";
+	public static final String LAUNCH = "launch";
 
 	@Override
 	public void launch(ILaunchConfiguration configuration, String mode, ILaunch launch, IProgressMonitor monitor)
@@ -108,14 +110,9 @@ public class ChromeRunDAPDebugDelegate extends AbstractHTMLDebugDelegate {
 
 		param.put(SOURCE_MAPS, true);
 		
-		// Let user point to the location of their Chrome executable
-		String chromeLocation = findChromeLocation(configuration);
-		File executable = chromeLocation != null && !chromeLocation.isBlank() ? new File(chromeLocation) : null;
-		if (executable == null || !executable.isAbsolute() || !executable.canExecute()) {
-			MessageUtils.showBrowserLocationsConfigurationError(Activator.getShell(), configuration, mode, Messages.RuntimeExecutable_Chrome, true);
-			return;
-		}
-		param.put(RUNTIME_EXECUTABLE, chromeLocation);
+		//Tell the debugger that we want to start a chrome debug session 
+		param.put(TYPE, CHROME);
+		param.put(REQUEST, LAUNCH);
 		
 		if (configuration.getAttribute(VERBOSE, false)) {
 			param.put(TRACE, VERBOSE);

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/chrome/ChromeRunDebugTabGroup.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/chrome/ChromeRunDebugTabGroup.java
@@ -26,7 +26,6 @@ public class ChromeRunDebugTabGroup extends AbstractLaunchConfigurationTabGroup 
 		setTabs(new ILaunchConfigurationTab[] {
 			new RunChromeDebugTab(),
 			new EnvironmentTab(),
-			new ChromeExecutableTab(),
 			new DSPOverrideSettingsTab(),
 			new CommonTab()
 		});


### PR DESCRIPTION
# Rationale # 
The "vscode-chrome-debug" debugger can either be instructed to start chrome from a specific path or it can try to locate chrome itself. See here: https://github.com/microsoft/vscode-chrome-debug/blob/master/src/chromeDebugAdapter.ts
If going for the first option the `runtimeExecutable` parameter must be specified. This is what wwd currently does and what causes #1327

In contrast, here is a typical `launch.json` from VSCode: 
```
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "type": "chrome",
            "request": "launch",
            "name": "Launch Chrome against localhost",
            "url": "http://localhost:4200/",
            "webRoot": "${workspaceFolder}/src",
            "sourceMaps":true
        }
    ]
}
```
Instead of using the `runtimeExecutable` parameter, VSCode uses the `type` and `launch` parameters. When the `type` and `launch` parameters are used "vscode-chrome-debug" locates the chrome executable itself. This fixes #1327 

I am not sure why it fixes #1327, but it does. 

# Appendix # 
This only fixes "Chrome Debug" and _not_ "Running Chrome Debug Instance". I suspect that "Running Chrome Debug Instance" can be fixed in the same way. After also fixing "Running Chrome Debug Instance" the class `ChromeExecutableTab` probably becomes obsolete. The method `findChromeLocation` in `ChromeRunDAPDebugDelegate` can probably also be deleted. 
