### PR TITLE
Fix #1332 - Add autoinsert support

### DIFF
--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -769,7 +769,7 @@
            base-type="org.eclipse.wildwebdeveloper.parent"
            file-extensions="vue"
            id="org.eclipse.wildwebdeveloper.vue"
-           name="VUE module"
+           name="VUE component"
            priority="normal">
      </content-type>
    </extension>
@@ -777,6 +777,7 @@
       <server
             class="org.eclipse.wildwebdeveloper.vue.VueLanguageServer"
             clientImpl="org.eclipse.wildwebdeveloper.vue.VueClientImpl"
+            serverInterface="org.eclipse.wildwebdeveloper.vue.VueLanguageServerAPI"
             id="org.eclipse.wildwebdeveloper.vue"
             label="VUE Language Server"/>
       <contentTypeMapping contentType="org.eclipse.wildwebdeveloper.vue" id="org.eclipse.wildwebdeveloper.vue"/>
@@ -818,6 +819,14 @@
             path="language-configurations/vue/vue-language-configuration.json">
       </languageConfiguration>
       
+   </extension>
+   
+   <extension
+         point="org.eclipse.ui.genericeditor.reconcilers">
+      <reconciler
+            class="org.eclipse.wildwebdeveloper.vue.autoinsert.VueAutoInsertReconciler"
+            contentType="org.eclipse.wildwebdeveloper.vue">
+      </reconciler>
    </extension>
 
    <!-- YAML Language -->   

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/vue/VueLanguageServerAPI.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/vue/VueLanguageServerAPI.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Dawid Pakuła and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Dawid Pakuła - initial implementation
+ *******************************************************************************/
+package org.eclipse.wildwebdeveloper.vue;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.eclipse.wildwebdeveloper.vue.autoinsert.AutoInsertParams;
+import org.eclipse.wildwebdeveloper.vue.autoinsert.AutoInsertResponse;
+
+/**
+ * VUE language server API which defines custom LSP commands.
+ *
+ */
+public interface VueLanguageServerAPI extends LanguageServer {
+
+	/**
+	 * Auto insert custom LSP command provided by the HTML language server to
+	 * support auto close tag and auto insert of quote for attribute.
+	 * 
+	 * @param params auto insert parameters.
+	 * @return the content with the auto close tag / auto insert of quote and null
+	 *         otherwise.
+	 * 
+	 */
+	@JsonRequest("volar/client/autoInsert")
+	CompletableFuture<Either<String, AutoInsertResponse>> autoInsert(AutoInsertParams params);
+	
+
+}

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/vue/autoinsert/AutoInsertLastChange.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/vue/autoinsert/AutoInsertLastChange.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Dawid Pakuła and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Dawid Pakuła - initial implementation
+ *******************************************************************************/
+package org.eclipse.wildwebdeveloper.vue.autoinsert;
+
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
+
+/**
+ * VUE Auto Insert parameters.
+ * 
+ */
+public class AutoInsertLastChange extends TextDocumentContentChangeEvent {
+
+	private int rangeOffset;
+
+	public int getRangeOffset() {
+		return rangeOffset;
+	}
+
+	public void setRangeOffset(int rangeOffset) {
+		this.rangeOffset = rangeOffset;
+	}
+}

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/vue/autoinsert/AutoInsertOptions.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/vue/autoinsert/AutoInsertOptions.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Dawid Pakuła and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Dawid Pakuła - initial implementation
+ *******************************************************************************/
+package org.eclipse.wildwebdeveloper.vue.autoinsert;
+
+public class AutoInsertOptions {
+
+	private AutoInsertLastChange lastChange;
+
+	public AutoInsertLastChange getLastChange() {
+		return lastChange;
+	}
+
+	public void setLastChange(AutoInsertLastChange lastChange) {
+		this.lastChange = lastChange;
+	}
+	
+}

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/vue/autoinsert/AutoInsertParams.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/vue/autoinsert/AutoInsertParams.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Dawid Pakuła and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Dawid Pakuła - initial implementation
+ *******************************************************************************/
+package org.eclipse.wildwebdeveloper.vue.autoinsert;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+
+/**
+ * VUE Auto Insert parameters.
+ * 
+ */
+public class AutoInsertParams {
+
+	/**
+	 * The text document.
+	 */
+	private TextDocumentIdentifier textDocument;
+	/**
+	 * The position inside the text document.
+	 */
+	private Position position;
+	
+	private AutoInsertOptions options;
+	
+
+	public TextDocumentIdentifier getTextDocument() {
+		return textDocument;
+	}
+
+	public void setTextDocument(TextDocumentIdentifier textDocument) {
+		this.textDocument = textDocument;
+	}
+
+	public Position getPosition() {
+		return position;
+	}
+
+	public void setPosition(Position position) {
+		this.position = position;
+	}
+	
+	public AutoInsertOptions getOptions() {
+		return options;
+	}
+
+	public void setOptions(AutoInsertOptions options) {
+		this.options = options;
+	}
+
+}

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/vue/autoinsert/AutoInsertResponse.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/vue/autoinsert/AutoInsertResponse.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Dawid Pakuła and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Dawid Pakuła - initial implementation
+ *******************************************************************************/
+package org.eclipse.wildwebdeveloper.vue.autoinsert;
+
+import org.eclipse.lsp4j.Range;
+
+/**
+ * VUE Auto Insert parameters.
+ * 
+ */
+public class AutoInsertResponse {
+
+	private String newText;
+	
+	private Range range;
+
+	public String getNewText() {
+		return newText;
+	}
+
+	public void setNewText(String newText) {
+		this.newText = newText;
+	}
+
+	public Range getRange() {
+		return range;
+	}
+
+	public void setRange(Range range) {
+		this.range = range;
+	}
+
+}

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/vue/autoinsert/VueAutoInsertReconciler.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/vue/autoinsert/VueAutoInsertReconciler.java
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2023 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Angelo ZERR (Red Hat Inc.) - initial implementation
+ *  Dawid Pakuła - modified copy for Vue
+ *******************************************************************************/
+package org.eclipse.wildwebdeveloper.vue.autoinsert;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.DocumentEvent;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentListener;
+import org.eclipse.jface.text.ITextInputListener;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.reconciler.IReconciler;
+import org.eclipse.jface.text.reconciler.IReconcilingStrategy;
+import org.eclipse.lsp4e.LSPEclipseUtils;
+import org.eclipse.lsp4e.LanguageServers;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.wildwebdeveloper.Activator;
+import org.eclipse.wildwebdeveloper.vue.VueLanguageServerAPI;
+
+/**
+ * {@link IReconciler} implementation used to support auto close tags / auto
+ * insert quote, features provides by the vscode VUE language server with the
+ * custom 'volar/client/autoInsert' LSP request.
+ *
+ */
+public class VueAutoInsertReconciler implements IReconciler {
+
+	private IDocument document;
+
+	private ITextViewer viewer;
+
+	private Listener listener;
+
+	private void autoInsert(DocumentEvent event) {
+		if (event == null || viewer == null) {
+			return;
+		}
+		IDocument document = event.getDocument();
+		if (document == null || event == null || event.getLength() != 0) {
+			return;
+		}
+
+		int offset = event.getOffset();
+		URI uri = LSPEclipseUtils.toUri(document);
+		if (uri == null) {
+			return;
+		}
+		
+		
+		TextDocumentIdentifier identifier = new TextDocumentIdentifier(uri.toString());
+		
+		LanguageServers.forDocument(document).collectAll((w, ls) -> CompletableFuture.completedFuture(ls))
+				.thenAccept(lss -> lss.stream().filter(VueLanguageServerAPI.class::isInstance)
+						.map(VueLanguageServerAPI.class::cast).findAny().ifPresent(info -> {
+							// The document is bound with HTML language server, consumes the html/autoInsert
+							final Display display = viewer.getTextWidget().getDisplay();
+							CompletableFuture.supplyAsync(() -> {
+								try {
+									// Wait for textDocument/didChange
+									Thread.sleep(100);
+								} catch (InterruptedException ex) {
+									Thread.interrupted();
+								}
+								try {
+									
+									AutoInsertParams params = new AutoInsertParams();
+									params.setTextDocument(identifier);
+									params.setPosition(LSPEclipseUtils.toPosition(offset + event.getText().length(), document));
+									
+									AutoInsertOptions opts = new AutoInsertOptions();
+									AutoInsertLastChange changeEvent = new AutoInsertLastChange();
+									final var range = new Range(LSPEclipseUtils.toPosition(offset, document),
+											LSPEclipseUtils.toPosition(offset + event.fLength, document));
+									changeEvent.setRange(range);
+									changeEvent.setText(event.getText());
+									changeEvent.setRangeLength(event.fLength);
+									changeEvent.setRangeOffset(offset);
+									opts.setLastChange(changeEvent);
+									params.setOptions(opts);
+
+									// consumes String or AutoInsertResponse from Vue Server
+									info.autoInsert(params)
+											.thenAccept(response -> {
+												if (response != null) { 
+													display.asyncExec(() -> {
+														try {
+															// we receive a text like
+															// $0</foo>
+															// $0 should be used for set the cursor.
+															String newText = response.map(Function.identity(), AutoInsertResponse::getNewText);
+															
+															String text = newText.replace("$0", "").replace("$1", "");
+															
+															
+															int index = newText.indexOf("$0");
+
+															int replaceLength = 0;
+															int replacePosition = offset + event.getText().length();
+															if (response.isRight()) {
+																replacePosition = LSPEclipseUtils.toOffset(response.getRight().getRange().getStart(), document);
+															}
+															document.replace(replacePosition, replaceLength, text);
+															if (index != -1) {
+																viewer.setSelectedRange(replacePosition + index, 0);
+															}
+															// viewer.setSelectedRange(offset, c)
+														} catch (BadLocationException e) {
+															Activator.getDefault().getLog().error(e.getMessage(), e);
+														}
+													});
+
+												}
+											});
+								} catch (BadLocationException e) {
+									// Do nothing
+									Activator.getDefault().getLog().error(e.getMessage(), e);
+								}
+								return null;
+							});
+						}));
+	}
+
+	/**
+	 * Internal document listener and text input listener.
+	 */
+	class Listener implements IDocumentListener, ITextInputListener {
+
+		/*
+		 * @see IDocumentListener#documentAboutToBeChanged(DocumentEvent)
+		 */
+		@Override
+		public void documentAboutToBeChanged(DocumentEvent e) {
+		}
+
+		/*
+		 * @see IDocumentListener#documentChanged(DocumentEvent)
+		 */
+		@Override
+		public void documentChanged(DocumentEvent e) {
+			System.out.println(e.toString());
+			autoInsert(e);
+		}
+
+		/*
+		 * @see ITextInputListener#inputDocumentAboutToBeChanged(IDocument, IDocument)
+		 */
+		@Override
+		public void inputDocumentAboutToBeChanged(IDocument oldInput, IDocument newInput) {
+			if (oldInput == document) {
+				if (document != null) {
+					document.removeDocumentListener(this);
+				}
+				document = null;
+			}
+		}
+
+		/*
+		 * @see ITextInputListener#inputDocumentChanged(IDocument, IDocument)
+		 */
+		@Override
+		public void inputDocumentChanged(IDocument oldInput, IDocument newInput) {
+			document = newInput;
+			if (document == null) {
+				return;
+			}
+			document.addDocumentListener(this);
+		}
+
+	}
+
+	@Override
+	public void install(ITextViewer viewer) {
+		this.viewer = viewer;
+		listener = new Listener();
+		viewer.addTextInputListener(listener);
+	}
+
+	@Override
+	public void uninstall() {
+		if (listener != null) {
+			viewer.removeTextInputListener(listener);
+			if (document != null) {
+				document.removeDocumentListener(listener);
+			}
+			listener = null;
+		}
+		this.viewer = null;
+	}
+
+	@Override
+	public IReconcilingStrategy getReconcilingStrategy(String contentType) {
+		return null;
+	}
+
+}


### PR DESCRIPTION
I started from AutoInsert reconciler, but as the result , there is a quiet big path:

1. AutoInsert support
2. Original VSCode preferences mapper (plus registered preferences in Eclipse) - I'm reading descriptions and types from vscode plugin package.json and map to IEclipsePreferences
3. Vue server can consume preferences from CSS/HTML/JS/TS and probably others (see fallbackCollect)
4. Special map for "typescript-server" settings to vscode settings aliases (vue require names as in vscode settings.json)
5. typescript-server-vue plugin

In general, preference support is nighmare. If server can consume extra preferences, each section server have to be mapped manually. I think this should be somehow pluggable, probably on LSP4E level