### PR TITLE
Fix #1247 - Maven build use node from PATH on mac os

### DIFF
--- a/org.eclipse.wildwebdeveloper.embedder.node.feature/feature.xml
+++ b/org.eclipse.wildwebdeveloper.embedder.node.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wildwebdeveloper.embedder.node.feature"
       label="%name"
-      version="1.0.6.qualifier"
+      version="1.0.7.qualifier"
       provider-name="Eclipse Wild Web Developer project"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.wildwebdeveloper.embedder.node.feature/pom.xml
+++ b/org.eclipse.wildwebdeveloper.embedder.node.feature/pom.xml
@@ -7,7 +7,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.6-SNAPSHOT</version>
+	<version>1.0.7-SNAPSHOT</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/org.eclipse.wildwebdeveloper.embedder.node/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Manager for embedded Node.js
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node
-Bundle-Version: 1.0.2.qualifier
+Bundle-Version: 1.0.3.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wildwebdeveloper.embedder.node/pom.xml
+++ b/org.eclipse.wildwebdeveloper.embedder.node/pom.xml
@@ -7,7 +7,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>1.0.2-SNAPSHOT</version>
+	<version>1.0.3-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper.embedder.node/src/org/eclipse/wildwebdeveloper/embedder/node/NodeJSManager.java
+++ b/org.eclipse.wildwebdeveloper.embedder.node/src/org/eclipse/wildwebdeveloper/embedder/node/NodeJSManager.java
@@ -22,6 +22,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 import org.eclipse.core.internal.runtime.InternalPlatform;
@@ -117,11 +120,67 @@ public class NodeJSManager {
 		File nodeJsLocation = getNodeJsLocation();
 		if (nodeJsLocation != null) {
 			File res = new File(nodeJsLocation.getParentFile(), npmFileName);
-			if (res.canExecute()) {
+			if (res.exists()) {
 				return res;
 			}
 		}
 		return which(npmFileName);
+	}
+	
+	public static File getNpmJSLocation() {
+	
+		try {
+			File npmLocation = getNpmLocation().getCanonicalFile();
+			if (npmLocation.getAbsolutePath().endsWith(".js")) {
+				return npmLocation;
+			}
+			String path = "node_modules/npm/bin/npm-cli.js";
+			if (new File(npmLocation.getParentFile(), "node_modules").exists()) {
+				return new File(npmLocation.getParentFile(), path);
+			}
+			File target = new File( npmLocation.getParentFile().getParentFile(), path);
+			if (target.exists()) {
+				return target;
+			}
+			
+			
+			return new File( npmLocation.getParentFile(), "lib/cli.js");
+		} catch (IOException e) {
+		}
+		
+		return null;
+		
+		
+	}
+	
+	public static ProcessBuilder prepareNodeProcessBuilder(String... commands)
+	{
+		return prepareNodeProcessBuilder(Arrays.asList(commands));
+	}
+	
+	public static ProcessBuilder prepareNodeProcessBuilder(List<String> commands)
+	{
+		List<String> tmp = new ArrayList<>();
+		tmp.add(getNodeJsLocation().getAbsolutePath());
+		tmp.addAll(commands);
+		
+		return new ProcessBuilder(tmp);
+	}
+	
+	public static ProcessBuilder prepareNPMProcessBuilder(String... commands)
+	{
+		return prepareNPMProcessBuilder(Arrays.asList(commands));
+	}
+	
+	public static ProcessBuilder prepareNPMProcessBuilder(List<String> commands)
+	{
+		List<String> tmp = new ArrayList<>();
+		
+		
+		tmp.add(getNpmJSLocation().getAbsolutePath());
+		tmp.addAll(commands);
+		
+		return prepareNodeProcessBuilder(tmp);
 	}
 
 	public static File which(String program) {

--- a/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestAngular.java
+++ b/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestAngular.java
@@ -51,8 +51,8 @@ public class TestAngular {
 		AllCleanRule.enableLogging();
 
 		project = Utils.provisionTestProject("angular-app");
-		ProcessBuilder builder = new ProcessBuilder(NodeJSManager.getNpmLocation().getAbsolutePath(), "install",
-				"--no-bin-links", "--ignore-scripts").directory(project.getLocation().toFile());
+		ProcessBuilder builder = NodeJSManager.prepareNPMProcessBuilder("install", "--no-bin-links", "--ignore-scripts")
+				.directory(project.getLocation().toFile());
 		Process process = builder.start();
 		System.out.println(builder.command().toString());
 		String result = new BufferedReader(new InputStreamReader(process.getErrorStream())).lines()

--- a/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestESLint.java
+++ b/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestESLint.java
@@ -78,8 +78,8 @@ class TestESLint {
 		try (InputStream eslintRc = TestESLint.class.getResourceAsStream("/testProjects/eslint/ESLintProj.js")) {
 			Files.copy(eslintRc, new File(projectDirectory, "ESLintProj.tsx").toPath());
 		}
-		ProcessBuilder builder = new ProcessBuilder(NodeJSManager.getNpmLocation().getAbsolutePath(), "install",
-				"--no-bin-links", "--ignore-scripts").directory(projectDirectory);
+		ProcessBuilder builder = NodeJSManager.prepareNPMProcessBuilder("install", "--no-bin-links", "--ignore-scripts")
+				.directory(projectDirectory);
 		Process dependencyInstaller = builder.start();
 		System.out.println(builder.command().toString());
 		String result = new BufferedReader(new InputStreamReader(dependencyInstaller.getErrorStream())).lines()

--- a/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestVue.java
+++ b/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestVue.java
@@ -55,8 +55,8 @@ public class TestVue {
 		AllCleanRule.enableLogging();
 
 		project = Utils.provisionTestProject("vue-app");
-		ProcessBuilder builder = new ProcessBuilder(NodeJSManager.getNpmLocation().getAbsolutePath(), "install",
-				"--no-bin-links", "--ignore-scripts").directory(project.getLocation().toFile());
+		ProcessBuilder builder = NodeJSManager.prepareNPMProcessBuilder("install", "--no-bin-links", "--ignore-scripts")
+				.directory(project.getLocation().toFile());
 		Process process = builder.start();
 		System.out.println(builder.command().toString());
 		String result = new BufferedReader(new InputStreamReader(process.getErrorStream())).lines()

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -193,6 +193,7 @@
 								<arg>pack</arg>
 								<arg>--no-bin-links</arg>
 								<arg>--ignore-scripts</arg>
+								<arg>--install-strategy=hoisted</arg>
 								<arg>vscode/VSCode-linux-x64/resources/app/extensions/html-language-features/server</arg>
 								<arg>vscode/VSCode-linux-x64/resources/app/extensions/css-language-features/server</arg>
 								<arg>vscode/VSCode-linux-x64/resources/app/extensions/json-language-features/server</arg>

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/npm/NpmLaunchDelegate.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/npm/NpmLaunchDelegate.java
@@ -63,7 +63,7 @@ public class NpmLaunchDelegate implements ILaunchConfigurationDelegate {
 		final String argumentString = VariablesPlugin.getDefault().getStringVariableManager().performStringSubstitution(configuration.getAttribute(ARGUMENTS, "No NPM argument set") //$NON-NLS-1$
 				.trim());
 		List<String> arguments = new ArrayList<>();
-		arguments.add(NodeJSManager.getNpmLocation().getAbsolutePath());
+		arguments.addAll(NodeJSManager.prepareNPMProcessBuilder().command());
 		arguments.addAll(Arrays.asList(argumentString.split(" "))); //$NON-NLS-1$
 		monitor.beginTask(argumentString + ' ' + packageJSON.getAbsolutePath(), 2);
 		monitor.worked(1);


### PR DESCRIPTION
Introduce NodeJSManager helpers to always produce ProcessBuilder with commands:

node_executable npm_location rest commands

these command is also used in NpmLaunchDelegate!