### PR TITLE
Allow configuring directory of ESLint package

### DIFF
--- a/org.eclipse.wildwebdeveloper.feature/feature.xml
+++ b/org.eclipse.wildwebdeveloper.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wildwebdeveloper.feature"
       label="%name"
-      version="1.3.3.qualifier"
+      version="1.3.4.qualifier"
       provider-name="Eclipse Wild Web Developer project"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.wildwebdeveloper.feature/pom.xml
+++ b/org.eclipse.wildwebdeveloper.feature/pom.xml
@@ -7,7 +7,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-feature</packaging>
-	<version>1.3.3-SNAPSHOT</version>
+	<version>1.3.4-SNAPSHOT</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper;singleton:=true
 Automatic-Module-Name: org.eclipse.wildwebdeveloper
-Bundle-Version: 1.1.4.qualifier
+Bundle-Version: 1.1.5.qualifier
 Bundle-Activator: org.eclipse.wildwebdeveloper.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -7,7 +7,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>1.1.4-SNAPSHOT</version>
+	<version>1.1.5-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/eslint/ESLintClientImpl.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/eslint/ESLintClientImpl.java
@@ -6,6 +6,9 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Pierre-Yves Bigourdan - Allow configuring directory of ESLint package
  *******************************************************************************/
 package org.eclipse.wildwebdeveloper.eslint;
 
@@ -30,6 +33,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.browser.IWorkbenchBrowserSupport;
 import org.eclipse.wildwebdeveloper.Activator;
+import org.eclipse.wildwebdeveloper.jsts.ui.preferences.JSTSPreferenceServerConstants;
 
 public class ESLintClientImpl extends LanguageClientImpl implements ESLintLanguageServerExtension {
 
@@ -75,9 +79,16 @@ public class ESLintClientImpl extends LanguageClientImpl implements ESLintLangua
 		config.put("workingDirectory", Collections.singletonMap("mode", "auto")); 
 
 
-		// this should not point to a nodejs executable but nodePath is the path to the "node_modules" 
-		// (or a parent having node modules, we just push in the highest dir (workspaceFolder) that has the package.json)
-		config.put("nodePath", highestPackageJsonDir.getAbsolutePath());
+		String eslintNodePath = JSTSPreferenceServerConstants.getESLintNodePath();
+		if (eslintNodePath.isEmpty()) {
+			// this should not point to a nodejs executable but nodePath is the path to the
+			// "node_modules" (or a parent having node modules, we just push in the highest
+			// dir (workspaceFolder) that has the package.json)
+			config.put("nodePath", highestPackageJsonDir.getAbsolutePath());
+		} else {
+			config.put("nodePath", eslintNodePath);
+
+		}
 		
 		config.put("validate", "on");
 		config.put("run", "onType");

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/Messages.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/Messages.java
@@ -9,6 +9,7 @@
  * Contributors:
  *  Angelo ZERR (Red Hat Inc.) - initial implementation
  *  Pierre-Yves Bigourdan - Allow using TypeScript version specified by project
+ *  Pierre-Yves Bigourdan - Allow configuring directory of ESLint package
  *******************************************************************************/
 package org.eclipse.wildwebdeveloper.jsts.ui;
 
@@ -23,6 +24,8 @@ public class Messages extends NLS {
 	public static String JSTSPreferencePage_typeScriptVersion;
 	public static String JSTSPreferencePage_typeScriptVersion_eclipse;
 	public static String JSTSPreferencePage_typeScriptVersion_project;
+
+	public static String JSTSPreferencePage_eslintNodePath;
 
 	// --------- TypeScript Inlay Hints preference page
 	public static String TypeScriptInlayHintPreferencePage_showInlayHintsFor_label;

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/messages.properties
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/messages.properties
@@ -9,12 +9,14 @@
 # * Contributors:
 # *  Angelo ZERR (Red Hat Inc.) - initial implementation
 # *  Pierre-Yves Bigourdan - Allow using TypeScript version specified by project
+# *  Pierre-Yves Bigourdan - Allow configuring directory of ESLint package
 # *******************************************************************************/
 
 JSTSPreferencePage_typeScriptVersion=Typescript version used for JavaScript and TypeScript language features:
 JSTSPreferencePage_typeScriptVersion_eclipse=Eclipse version
 JSTSPreferencePage_typeScriptVersion_project=Project version
 
+JSTSPreferencePage_eslintNodePath=Directory where the ESLint package is installed:
 
 # TypeScript Inlay Hints preference page
 TypeScriptInlayHintPreferencePage_showInlayHintsFor_label=Show inlay hints for:

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/messages.properties
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/messages.properties
@@ -16,7 +16,7 @@ JSTSPreferencePage_typeScriptVersion=Typescript version used for JavaScript and 
 JSTSPreferencePage_typeScriptVersion_eclipse=Eclipse version
 JSTSPreferencePage_typeScriptVersion_project=Project version
 
-JSTSPreferencePage_eslintNodePath=Directory where the ESLint package is installed:
+JSTSPreferencePage_eslintNodePath=Absolute or project-relative path containing the eslint folder (node_modules used if blank):
 
 # TypeScript Inlay Hints preference page
 TypeScriptInlayHintPreferencePage_showInlayHintsFor_label=Show inlay hints for:

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/preferences/JSTSPreferencePage.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/preferences/JSTSPreferencePage.java
@@ -19,8 +19,8 @@ import static org.eclipse.wildwebdeveloper.jsts.ui.preferences.JSTSPreferenceSer
 import static org.eclipse.wildwebdeveloper.jsts.ui.preferences.JSTSPreferenceServerConstants.TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_PROJECT;
 
 import org.eclipse.jface.preference.ComboFieldEditor;
-import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
@@ -53,6 +53,6 @@ public class JSTSPreferencePage extends FieldEditorPreferencePage implements IWo
 						{ Messages.JSTSPreferencePage_typeScriptVersion_project,
 								TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_PROJECT } },
 				parent));
-		addField(new DirectoryFieldEditor(ESLINT_PREFERENCES_NODE_PATH, Messages.JSTSPreferencePage_eslintNodePath, parent));
+		addField(new StringFieldEditor(ESLINT_PREFERENCES_NODE_PATH, Messages.JSTSPreferencePage_eslintNodePath, parent));
 	}
 }

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/preferences/JSTSPreferencePage.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/preferences/JSTSPreferencePage.java
@@ -9,14 +9,17 @@
  *
  * Contributors:
  *  Angelo ZERR (Red Hat Inc.) - initial implementation
+ *  Pierre-Yves Bigourdan - Allow configuring directory of ESLint package
  *******************************************************************************/
 package org.eclipse.wildwebdeveloper.jsts.ui.preferences;
 
+import static org.eclipse.wildwebdeveloper.jsts.ui.preferences.JSTSPreferenceServerConstants.ESLINT_PREFERENCES_NODE_PATH;
 import static org.eclipse.wildwebdeveloper.jsts.ui.preferences.JSTSPreferenceServerConstants.TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION;
 import static org.eclipse.wildwebdeveloper.jsts.ui.preferences.JSTSPreferenceServerConstants.TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_ECLIPSE;
 import static org.eclipse.wildwebdeveloper.jsts.ui.preferences.JSTSPreferenceServerConstants.TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_PROJECT;
 
 import org.eclipse.jface.preference.ComboFieldEditor;
+import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbench;
@@ -50,5 +53,6 @@ public class JSTSPreferencePage extends FieldEditorPreferencePage implements IWo
 						{ Messages.JSTSPreferencePage_typeScriptVersion_project,
 								TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_PROJECT } },
 				parent));
+		addField(new DirectoryFieldEditor(ESLINT_PREFERENCES_NODE_PATH, Messages.JSTSPreferencePage_eslintNodePath, parent));
 	}
 }

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/preferences/JSTSPreferenceServerConstants.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/ui/preferences/JSTSPreferenceServerConstants.java
@@ -25,14 +25,22 @@ public class JSTSPreferenceServerConstants {
 
 	public static final String TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_ECLIPSE = "Eclipse version";
 	public static final String TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_PROJECT = "Project version";
+	
+	public static final String ESLINT_PREFERENCES_NODE_PATH = "eslint.nodePath";
 
 	public static String getTypeScriptVersion() {
 		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
 		return store.getString(TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION);
 	}
 
+	public static String getESLintNodePath() {
+		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
+		return store.getString(ESLINT_PREFERENCES_NODE_PATH);
+	}
+
 	public static void initializeDefaultPreferences() {
 		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
 		store.setDefault(TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION, TYPESCRIPT_PREFERENCES_TSSERVER_TYPESCRIPT_VERSION_ECLIPSE);
+		store.setDefault(ESLINT_PREFERENCES_NODE_PATH, "");
 	}
 }

--- a/repository/epp.product
+++ b/repository/epp.product
@@ -3,7 +3,7 @@
 
 <product name="Eclipse IDE for JavaScript and Web Developers" uid="org.eclipse.wildwebdeveloper.product" 
 	id="org.eclipse.wildwebdeveloper.product.branding.product" application="org.eclipse.ui.ide.workbench" 
-	version="1.3.3.qualifier" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
+	version="1.3.4.qualifier" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.wildwebdeveloper.product.branding.product/eclipse_lg.png"/>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -7,7 +7,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-repository</packaging>
-	<version>1.3.3-SNAPSHOT</version>
+	<version>1.3.4-SNAPSHOT</version>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
By default, the ESLint language server will try to find the ESLint package in `node_modules` at the root of the project. However, it may be in a different place, for example when using non-NPM package managers. This PR adds a preference to configure the location.

I've added the new preference to the existing JS/TS preferences page. Even though a different language server, ESLint is strongly tied to JS and TS, it didn't feel right to introduce a separate bespoke page just for this preference.