### PR TITLE
[build] Use wikitext feature from Eclipse releases

### DIFF
--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -30,15 +30,12 @@
 	<unit id="org.eclipse.rse.feature.group" version="0.0.0"/>
 	<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
 	<unit id="org.eclipse.platform.ide" version="0.0.0"/>
+	<unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<repository location="https://download.eclipse.org/tm4e/releases/latest/"/>
 	<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
 	<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-	<repository location="https://download.eclipse.org/mylyn/docs/releases/"/>
-	<unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<!--⚠️ Use release when LSP4E release contains https://github.com/eclipse/lsp4e/commit/909c41fb6d80895388634f152b7f9dd20f9482b8 https://github.com/eclipse/lsp4e/commit/909c41fb6d80895388634f152b7f9dd20f9482b8 -->


### PR DESCRIPTION
Wikitext update site https://download.eclipse.org/mylyn/docs/releases/ doesn't ptovide the latest version by default, so it needs to either point to a certain version (and update on the regular baasis) or switch it to be downloaded from the latest Eclipse release (to use the same version as the one used in  Eclipse release)