### PR TITLE
fix: misspelled "#property-values" include

### DIFF
--- a/org.eclipse.wildwebdeveloper/grammars/css/css.tmLanguage.json
+++ b/org.eclipse.wildwebdeveloper/grammars/css/css.tmLanguage.json
@@ -1057,7 +1057,7 @@
 							"name": "support.constant.text-direction.css"
 						},
 						{
-							"include": "#property-value"
+							"include": "#property-values"
 						}
 					]
 				},


### PR DESCRIPTION
The file does not define a `property-value` but not a `property-values` rule - which is correctly referenced in all other include directives.