### PR TITLE
Fix preferences layout

### DIFF
--- a/org.eclipse.wildwebdeveloper.xml.feature/feature.xml
+++ b/org.eclipse.wildwebdeveloper.xml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wildwebdeveloper.xml.feature"
       label="%name"
-      version="1.3.1.qualifier"
+      version="1.3.2.qualifier"
       provider-name="Eclipse Wild Web Developer project"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
@@ -21,9 +21,6 @@
 
    <plugin
          id="org.eclipse.wildwebdeveloper.xml"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
 </feature>

--- a/org.eclipse.wildwebdeveloper.xml.feature/pom.xml
+++ b/org.eclipse.wildwebdeveloper.xml.feature/pom.xml
@@ -7,7 +7,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-feature</packaging>
-	<version>1.3.1-SNAPSHOT</version>
+	<version>1.3.2-SNAPSHOT</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/org.eclipse.wildwebdeveloper.xml/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.xml;singleton:=true
-Bundle-Version: 1.3.1.qualifier
+Bundle-Version: 1.3.2.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.xml

--- a/org.eclipse.wildwebdeveloper.xml/pom.xml
+++ b/org.eclipse.wildwebdeveloper.xml/pom.xml
@@ -7,7 +7,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>1.3.1-SNAPSHOT</version>
+	<version>1.3.2-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper.xml/src/org/eclipse/wildwebdeveloper/xml/internal/ui/messages.properties
+++ b/org.eclipse.wildwebdeveloper.xml/src/org/eclipse/wildwebdeveloper/xml/internal/ui/messages.properties
@@ -44,13 +44,13 @@ XMLFormattingPreferencePage_format_xsiSchemaLocationSplit_none=None
 XMLFormattingPreferencePage_format_maxLineWidth=Max line width
 XMLFormattingPreferencePage_format_grammarAwareFormatting=Use Schema/DTD grammar information while formatting
 XMLFormattingPreferencePage_format_preservedNewlines=Preserve new lines that separate tags. The value represents the maximum number\t\nof new lines per section. A value of 0 removes all new lines.
-XMLFormattingPreferencePage_format_joinContentLines=Normalize the whitespace of content inside an element. Newlines and \t\nwhitespace are removed
+XMLFormattingPreferencePage_format_joinContentLines=Normalize the whitespace of content inside an element. Newlines and whitespace are removed
 XMLFormattingPreferencePage_format_insertFinalNewline=Insert a final newline at the end of the document
 XMLFormattingPreferencePage_format_trimFinalNewlines=Trim final newlines at the end of the document
 XMLFormattingPreferencePage_format_trimTrailingWhitespace=Trim trailing whitespace
 XMLFormattingPreferencePage_format_preserveSpace=Preserve space
 XMLFormattingPreferencePage_format_joinCommentLines=Join &comment content on format
-XMLFormattingPreferencePage_format_joinCDATALines=Join C&DATAcontent on format
+XMLFormattingPreferencePage_format_joinCDATALines=Join C&DATA content on format
 
 PreserveSpaceFieldEditor_inputDialog_title=Preserve space tags
 PreserveSpaceFieldEditor_inputDialog_description=Fill tag which must preserve space


### PR DESCRIPTION
before
![grafik](https://github.com/eclipse-wildwebdeveloper/wildwebdeveloper/assets/406876/146a5855-0a3e-4310-8498-67024318270d)

and after
![grafik](https://github.com/eclipse-wildwebdeveloper/wildwebdeveloper/assets/406876/023db4e7-4240-4111-ab94-2ac62b256508)

Checkboxes (on Windows) don't have multiline text, at least not without additional magic, therefore the newline is invalid there.