### PR TITLE
Update docker image in buld to use Java 21 and Node.js 20

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ kind: Pod
 spec:
   containers:
   - name: container
-    image: docker.io/vrubezhny/fedora-gtk3-mutter-java-node:java-17-node-18
+    image: docker.io/akurtakov/fedora-gtk3-mutter-java-node:java-21-node-20
     imagePullPolicy: Always
     tty: true
     command: [ "uid_entrypoint", "cat" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,19 @@
-FROM eclipsecbi/fedora-gtk3-mutter:36-gtk3.24
+FROM eclipsecbi/fedora-gtk3-mutter:39-gtk3.24
 
 # Back to root for install
 USER 0
 RUN dnf -y update && dnf -y install \
-	java-17-openjdk-devel maven git
+	java-21-openjdk-devel git
 RUN dnf -y install nodejs npm
 RUN dnf -y install xz
 RUN dnf -y install procps-ng
 
-RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz | tar -xzv 
+RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz | tar -xzv 
 
-RUN curl -L https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz | tar -xJ
+RUN curl -L https://nodejs.org/dist/v20.11.1/node-v20.11.1-linux-x64.tar.xz | tar -xJ
 
-ENV PATH=/apache-maven-3.9.2/bin:/node-v18.16.0-linux-x64/bin:/usr/lib/jvm/java-17/bin:$PATH
-ENV JAVA_HOME=/usr/lib/jvm/java-17
+ENV PATH=/apache-maven-3.9.6/bin:/node-v20.11.1-linux-x64/bin:/usr/lib/jvm/java-21/bin:$PATH
+ENV JAVA_HOME=/usr/lib/jvm/java-21
 
 #Back to named user
 USER 10001


### PR DESCRIPTION
Aligns the node.js version with the one shipped in embedder. Uses Fedora 39 default JVM.