### PR TITLE
Reduce Jenkinsfile requested resources to 4Gi

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,10 +20,10 @@ spec:
     command: [ "uid_entrypoint", "cat" ]
     resources:
       limits:
-        memory: "6Gi"
+        memory: "4Gi"
         cpu: "2000m"
       requests:
-        memory: "6Gi"
+        memory: "4Gi"
         cpu: "1000m"
   - name: jnlp
     image: 'eclipsecbi/jenkins-jnlp-agent'


### PR DESCRIPTION
Hopefully this reduces(removes even) the pletora of "Failure executing: POST at: https://10.30.0.1:443/api/v1/namespaces/wildwebdeveloper/pods. Message: pods "wildwebdeveloper-buildtest-pod-1f87z-kqc01" is forbidden: exceeded quota: jenkins-instance-quota, requested: limits.memory=6400Mi,requests.memory=6400Mi, used: limits.memory=7936Mi,requests.memory=7936Mi, limited: limits.memory=10Gi,requests.memory=10Gi. Received status: Status(apiVersion=v1, code=403, details=StatusDetails(causes=[], group=null, kind=pods, name=wildwebdeveloper-buildtest-pod-1f87z-kqc01, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=pods "wildwebdeveloper-buildtest-pod-1f87z-kqc01" is forbidden: exceeded quota: jenkins-instance-quota, requested: limits.memory=6400Mi,requests.memory=6400Mi, used: limits.memory=7936Mi,requests.memory=7936Mi, limited: limits.memory=10Gi,requests.memory=10Gi,
metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=Forbidden, status=Failure, additionalProperties={})." in the build log.