### PR TITLE
Update commons-compress to 1.26.0

### DIFF
--- a/org.eclipse.wildwebdeveloper.embedder.node/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Import-Package: org.apache.commons.compress.archivers;version="1.22",
  org.apache.commons.compress.archivers.zip,
  org.apache.commons.compress.compressors.gzip,
  org.apache.commons.compress.compressors.xz,
- org.apache.commons.compress.utils
+ org.apache.commons.compress.utils,
+ org.apache.commons.io
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.wildwebdeveloper.embedder.node.Activator
 Export-Package: org.eclipse.wildwebdeveloper.embedder.node

--- a/org.eclipse.wildwebdeveloper.embedder.node/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Manager for embedded Node.js
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node
-Bundle-Version: 1.0.3.qualifier
+Bundle-Version: 1.0.4.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.wildwebdeveloper.embedder.node/pom.xml
+++ b/org.eclipse.wildwebdeveloper.embedder.node/pom.xml
@@ -7,14 +7,13 @@
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>1.0.3-SNAPSHOT</version>
+	<version>1.0.4-SNAPSHOT</version>
 
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-packaging-plugin</artifactId>
-				<version>${tycho-version}</version>
 				<configuration>
 					<jgit.ignore>
 						pom.xml

--- a/org.eclipse.wildwebdeveloper.embedder.node/src/org/eclipse/wildwebdeveloper/embedder/node/CompressUtils.java
+++ b/org.eclipse.wildwebdeveloper.embedder.node/src/org/eclipse/wildwebdeveloper/embedder/node/CompressUtils.java
@@ -28,75 +28,75 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
-import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.IOUtils;
 
 public class CompressUtils {
-	public static void unarchive(URL archiveURL, File baseDir) throws IOException {
-		if (archiveURL == null || baseDir == null) {
-			return;
-		}
-		ArchiveInputStream archive = null;
-		try (InputStream input = archiveURL.openStream()) {
-			if (archiveURL.getFile().endsWith(".tar.gz")) { //$NON-NLS-1$
-				InputStream gz = new GzipCompressorInputStream(input);
-				archive = new TarArchiveInputStream(gz);
-			} else if (archiveURL.getFile().endsWith(".tar.xz")) { //$NON-NLS-1$
-				InputStream xz = new XZCompressorInputStream(input);
-				archive = new TarArchiveInputStream(xz);
-			} else if (archiveURL.getFile().endsWith(".zip")) { //$NON-NLS-1$
-				archive = new ZipArchiveInputStream(input);
-			} else {
-				throw new UnsupportedCompressionAlgorithmException("Unsupported archive file extension: " + archive); //$NON-NLS-1$
-			}
-			try {
-				extractArchive(archive, baseDir);
-			} finally {
-				IOUtils.closeQuietly(archive);
-			}
-		}
-	}
-	
-	/**
-	 * Extract zip/tar.gz/tar.xz file to destination folder.
-	 * Sets up 'executable' permission for TarAchiveEntry representing an 
-	 * executable file.
-	 *
-	 * @param in
-	 *			Zip/Tar Archive Input Stream to extract
-	 * @param destination
-	 *			destination folder
-	 */
-	private static void extractArchive(ArchiveInputStream in, File destination) throws IOException {
-		ArchiveEntry entry = null;
-		while ((entry = in.getNextEntry()) != null) {
-			if (!in.canReadEntryData(entry)) {
-				// log something?
-				continue;
-			}
-			File f = new File(destination, entry.getName());
-			f.delete();
-			boolean symlink = entry instanceof TarArchiveEntry tarEntry && tarEntry.isSymbolicLink();
-			if (entry.isDirectory()) {
-				if (!f.isDirectory() && !f.mkdirs()) {
-					throw new IOException("failed to create directory " + f);
-				}
-			} else {
-				File parent = f.getParentFile();
-				if (!parent.isDirectory() && !parent.mkdirs()) {
-					throw new IOException("failed to create directory " + parent);
-				}
-				if (symlink) {
-					String linkName = ((TarArchiveEntry)entry).getLinkName();
-					Files.createSymbolicLink(f.toPath(), Paths.get(linkName));					
-				} else {
-					try (OutputStream o = Files.newOutputStream(f.toPath())) {
-						IOUtils.copy(in, o);
-					}
-				}
-				if (entry instanceof TarArchiveEntry tarEntry) {
-					f.setExecutable((tarEntry.getMode() & 256) != 0);
-				}
-			}
-		}
-	}
+    public static void unarchive(URL archiveURL, File baseDir) throws IOException {
+        if (archiveURL == null || baseDir == null) {
+            return;
+        }
+        ArchiveInputStream archive = null;
+        try (InputStream input = archiveURL.openStream()) {
+            if (archiveURL.getFile().endsWith(".tar.gz")) { //$NON-NLS-1$
+                InputStream gz = new GzipCompressorInputStream(input);
+                archive = new TarArchiveInputStream(gz);
+            } else if (archiveURL.getFile().endsWith(".tar.xz")) { //$NON-NLS-1$
+                InputStream xz = new XZCompressorInputStream(input);
+                archive = new TarArchiveInputStream(xz);
+            } else if (archiveURL.getFile().endsWith(".zip")) { //$NON-NLS-1$
+                archive = new ZipArchiveInputStream(input);
+            } else {
+                throw new UnsupportedCompressionAlgorithmException("Unsupported archive file extension: " + archive); //$NON-NLS-1$
+            }
+            try {
+                extractArchive(archive, baseDir);
+            } finally {
+                IOUtils.closeQuietly(archive);
+            }
+        }
+    }
+
+    /**
+     * Extract zip/tar.gz/tar.xz file to destination folder.
+     * Sets up 'executable' permission for TarAchiveEntry representing an
+     * executable file.
+     *
+     * @param in
+     *                    Zip/Tar Archive Input Stream to extract
+     * @param destination
+     *                    destination folder
+     */
+    private static void extractArchive(ArchiveInputStream in, File destination) throws IOException {
+        ArchiveEntry entry = null;
+        while ((entry = in.getNextEntry()) != null) {
+            if (!in.canReadEntryData(entry)) {
+                // log something?
+                continue;
+            }
+            File f = new File(destination, entry.getName());
+            f.delete();
+            boolean symlink = entry instanceof TarArchiveEntry tarEntry && tarEntry.isSymbolicLink();
+            if (entry.isDirectory()) {
+                if (!f.isDirectory() && !f.mkdirs()) {
+                    throw new IOException("failed to create directory " + f);
+                }
+            } else {
+                File parent = f.getParentFile();
+                if (!parent.isDirectory() && !parent.mkdirs()) {
+                    throw new IOException("failed to create directory " + parent);
+                }
+                if (symlink) {
+                    String linkName = ((TarArchiveEntry) entry).getLinkName();
+                    Files.createSymbolicLink(f.toPath(), Paths.get(linkName));
+                } else {
+                    try (OutputStream o = Files.newOutputStream(f.toPath())) {
+                        IOUtils.copy(in, o);
+                    }
+                }
+                if (entry instanceof TarArchiveEntry tarEntry) {
+                    f.setExecutable((tarEntry.getMode() & 256) != 0);
+                }
+            }
+        }
+    }
 }

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -85,7 +85,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-compress</artifactId>
-				<version>1.25.0</version>
+				<version>1.26.0</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
Commons-compress deprecated its own IOUtils in favor of commons-io thus code is migrated accordingly.