### PR TITLE
Streamline target platform

### DIFF
--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -7,6 +7,7 @@
 	<unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
 	<unit id="org.eclipse.pde.junit.runtime" version="0.0.0"/>
 	<unit id="org.eclipse.jdt.junit5.runtime" version="0.0.0"/>
+	<unit id="com.google.gson" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<repository location="https://download.eclipse.org/releases/latest/"/>
@@ -38,9 +39,7 @@
 	<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-	<!--⚠️ Use release when LSP4E release contains https://github.com/eclipse/lsp4e/commit/909c41fb6d80895388634f152b7f9dd20f9482b8 https://github.com/eclipse/lsp4e/commit/909c41fb6d80895388634f152b7f9dd20f9482b8 -->
-	<!--repository location="https://download.eclipse.org/lsp4e/releases/latest/"/-->
-	<repository location="https://download.eclipse.org/lsp4e/snapshots/"/>
+	<repository location="https://download.eclipse.org/lsp4e/releases/latest/"/>
 	<unit id="org.eclipse.lsp4e" version="0.0.0"/>
 	<unit id="org.eclipse.lsp4e.debug" version="0.0.0"/>
 	<unit id="org.eclipse.lsp4j" version="0.0.0"/>
@@ -86,16 +85,6 @@
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-compress</artifactId>
 				<version>1.26.0</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Google GSON" missingManifest="error" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>com.google.code.gson</groupId>
-				<artifactId>gson</artifactId>
-				<version>2.10.1</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
* Use released lsp4e.
* Use gson from Eclipse platform rather than define again.