### PR TITLE
Remove jakarta APIs from target platform

### DIFF
--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -51,34 +51,6 @@
 	<repository location="http://download.eclipse.org/cbi/updates/license/"/>
 	<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 </location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Jakarta APIs" missingManifest="error" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>jakarta.enterprise</groupId>
-				<artifactId>jakarta.enterprise.cdi-api</artifactId>
-				<version>2.0.2</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>jakarta.interceptor</groupId>
-				<artifactId>jakarta.interceptor-api</artifactId>
-				<version>1.2.5</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>jakarta.servlet</groupId>
-				<artifactId>jakarta.servlet-api</artifactId>
-				<version>4.0.4</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>jakarta.transaction</groupId>
-				<artifactId>jakarta.transaction-api</artifactId>
-				<version>1.3.3</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
 	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="Apache Commons Compress" missingManifest="error" type="Maven">
 		<dependencies>
 			<dependency>


### PR DESCRIPTION
They are not directly used in the codebase thus are better fetched by whatever requires them.