### PR TITLE
update lemminx to 0.28.0

### DIFF
--- a/org.eclipse.wildwebdeveloper.xml/pom.xml
+++ b/org.eclipse.wildwebdeveloper.xml/pom.xml
@@ -40,7 +40,7 @@
 									<groupId>org.eclipse.lemminx</groupId>
 									<artifactId>org.eclipse.lemminx</artifactId>
 									<!-- Bumping to version with API breakage needs to bump bundle version at least by +0.1.0 -->
-									<version>0.27.0</version>
+									<version>0.28.0</version>
 									<!-- classifier:uber includes all dependencies -->
 									<classifier>uber</classifier>
 								</artifactItem>


### PR DESCRIPTION
The lemminx language server in version 0.27.0 throws a nasty error in some cases (see https://github.com/eclipse/lemminx/issues/1653) that has been fixed on 0.28.0, so updating to that version would be awesome.