### PR TITLE
Register .cts and .mts file extensions with TypeScript content type

### DIFF
--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -461,7 +461,7 @@
       </content-type>
       <content-type
             base-type="org.eclipse.wildwebdeveloper.parent"
-            file-extensions="ts"
+            file-extensions="ts, cts, mts"
             id="org.eclipse.wildwebdeveloper.ts"
             name="TypeScript"
             priority="normal">


### PR DESCRIPTION
Vitepress for example uses `config.mts` when TypeScript is enabled.

See also https://www.totaltypescript.com/concepts/mjs-cjs-mts-and-cts-extensions