### PR TITLE
Consume lemminx as a bundle from the OSGi runtime

### DIFF
--- a/org.eclipse.wildwebdeveloper.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.wildwebdeveloper.tests/.settings/org.eclipse.jdt.core.prefs
@@ -13,3 +13,4 @@ org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=21
+org.eclipse.jdt.core.compiler.ignoreUnnamedModuleForSplitPackage=enabled

--- a/org.eclipse.wildwebdeveloper.xml.feature/feature.xml
+++ b/org.eclipse.wildwebdeveloper.xml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wildwebdeveloper.xml.feature"
       label="%name"
-      version="1.3.6.qualifier"
+      version="1.3.7.qualifier"
       provider-name="Eclipse Wild Web Developer project"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.wildwebdeveloper.xml.feature/pom.xml
+++ b/org.eclipse.wildwebdeveloper.xml.feature/pom.xml
@@ -7,7 +7,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-feature</packaging>
-	<version>1.3.6-SNAPSHOT</version>
+	<version>1.3.7-SNAPSHOT</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/org.eclipse.wildwebdeveloper.xml/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.xml;singleton:=true
-Bundle-Version: 1.3.6.qualifier
+Bundle-Version: 1.3.7.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.xml
@@ -23,7 +23,8 @@ Require-Bundle: org.eclipse.tm4e.registry;bundle-version="0.3.0",
  org.eclipse.text,
  org.eclipse.jface.text;bundle-version="3.20.100",
  com.google.gson,
- org.eclipse.tm4e.language_pack
+ org.eclipse.tm4e.language_pack,
+ org.eclipse.lemminx.uber-jar;bundle-version="[0.29.0,1.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.wildwebdeveloper.xml.internal.Activator
 Export-Package: org.eclipse.wildwebdeveloper.xml;x-friends:="org.eclipse.m2e.editor.lemminx",

--- a/org.eclipse.wildwebdeveloper.xml/build.properties
+++ b/org.eclipse.wildwebdeveloper.xml/build.properties
@@ -4,7 +4,6 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                plugin.properties,\
-               language-servers/server/,\
                language-configurations/,\
                grammars/,\
                snippets/,\

--- a/org.eclipse.wildwebdeveloper.xml/pom.xml
+++ b/org.eclipse.wildwebdeveloper.xml/pom.xml
@@ -7,50 +7,10 @@
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>1.3.6-SNAPSHOT</version>
+	<version>1.3.7-SNAPSHOT</version>
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-				<configuration>
-					<filesets>
-						<fileset>
-							<directory>language-servers/</directory>
-							<includes>*.tgz</includes>
-						</fileset>
-					</filesets>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.8.1</version>
-				<executions>
-					<execution>
-						<id>fetch-lemminx</id>
-						<phase>generate-resources</phase>
-						<goals>
-							<goal>copy</goal>
-						</goals>
-						<configuration>
-							<artifactItems>
-								<artifactItem>
-									<groupId>org.eclipse.lemminx</groupId>
-									<artifactId>org.eclipse.lemminx</artifactId>
-									<!-- Bumping to version with API breakage needs to bump bundle version at least by +0.1.0 -->
-									<version>0.29.0</version>
-									<!-- classifier:uber includes all dependencies -->
-									<classifier>uber</classifier>
-								</artifactItem>
-							</artifactItems>
-							<outputDirectory>language-servers/server</outputDirectory>
-							<stripVersion>true</stripVersion>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-packaging-plugin</artifactId>
@@ -62,17 +22,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<repositories>
-		<repository>
-			<id>lemminx-releases</id>
-			<url>https://repo.eclipse.org/content/repositories/lemminx-releases/</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</repository>
-	</repositories>
 </project>

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -54,5 +54,22 @@
 			</dependency>
 		</dependencies>
 	</location>
+	<location includeDependencyDepth="none" includeDependencyScopes="compile" label="LemMinX" missingManifest="error" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>org.eclipse.lemminx</groupId>
+				<artifactId>org.eclipse.lemminx</artifactId>
+				<version>0.29.0</version>
+				<type>jar</type>
+				<classifier>uber</classifier>
+			</dependency>
+		</dependencies>
+		<repositories>
+			<repository>
+				<id>lemminx-releases</id>
+				<url>https://repo.eclipse.org/content/repositories/lemminx-releases/</url>
+			</repository>
+		</repositories>
+	</location>
 </locations>
 </target>


### PR DESCRIPTION
Currently lemminx is embedded into WWD what has some disadvantages:

- the jar gets bigger
- the embedded jar needs to be extracted before it can be used
- version bumps are required for lemminx updates
- lemminx can't be updated independent from WWD

This now adds a require-bundle to the manifest (so we are getting a certain version we are compatible with) and uses the bundle wiring to get hold of the bundle and then transform it into a file path.

As discused here 
- https://github.com/eclipse-wildwebdeveloper/wildwebdeveloper/discussions/1712