### PR TITLE
Explicitly add packageManager to package.json to help dependabot

### DIFF
--- a/org.eclipse.wildwebdeveloper.tests/testProjects/eslint/package.json
+++ b/org.eclipse.wildwebdeveloper.tests/testProjects/eslint/package.json
@@ -13,5 +13,6 @@
 		"@typescript-eslint/parser": "^7.18.0",
 		"eslint": "^8.57.1",
 		"typescript": "5.7.3"
-	}
+	},
+  "packageManager": "npm@11"
 }


### PR DESCRIPTION
Without it, we get dependabot warnings "Dependabot does not support your npm version. Because of this, Dependabot cannot update this pull request."