### PR TITLE
Add org.eclipse.lemminx.uber-jar to the dependencies for category.xml

### DIFF
--- a/repository/category.xml
+++ b/repository/category.xml
@@ -72,6 +72,9 @@
    <bundle id="org.apache.commons.lang3" version="0.0.0">
       <category name="Dependencies"/>
    </bundle>
+   <bundle id="org.eclipse.lemminx.uber-jar" version="0.0.0">
+      <category name="Dependencies"/>
+   </bundle>
    <bundle id="org.snakeyaml.engine">
       <category name="Dependencies"/>
    </bundle>


### PR DESCRIPTION
With the latest release I noticed that the update site actually is missing the `org.eclipse.lemminx.uber-jar` what makes PDE complain:

```
Cannot complete the install because one or more required items could not be found.
	Cannot satisfy dependency:
		From: Wild Web Developer XML tools 1.3.7.202501161210 (org.eclipse.wildwebdeveloper.xml.feature.feature.group 1.3.7.202501161210)
		To: org.eclipse.equinox.p2.iu; org.eclipse.wildwebdeveloper.xml [1.3.7.202501161210,1.3.7.202501161210]
	Missing requirement: XML support using Language Server 1.3.7.202501161210 (org.eclipse.wildwebdeveloper.xml 1.3.7.202501161210) requires 'osgi.bundle; org.eclipse.lemminx.uber-jar [0.29.0,1.0.0)' but it could not be found
	Software being installed: Wild Web Developer XML tools 1.3.7.202501161210 (org.eclipse.wildwebdeveloper.xml.feature.feature.group 1.3.7.202501161210)
```