### PR TITLE
[tests] Fix Vue Template test

### DIFF
--- a/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestVue.java
+++ b/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestVue.java
@@ -45,127 +45,134 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class TestVue {
-    static IProject project;
-    static IFolder componentFolder;
+	static IProject project;
+	static IFolder componentFolder;
 
-    @BeforeAll
-    public static void setUp() throws Exception {
-        AllCleanRule.closeIntro();
-        AllCleanRule.enableLogging();
+	@BeforeAll
+	public static void setUp() throws Exception {
+		AllCleanRule.closeIntro();
+		AllCleanRule.enableLogging();
 
-        project = Utils.provisionTestProject("vue-app");
-        ProcessBuilder builder = NodeJSManager.prepareNPMProcessBuilder("install", "--no-bin-links", "--ignore-scripts")
-                .directory(project.getLocation().toFile());
-        Process process = builder.start();
-        System.out.println(builder.command().toString());
-        String result = process.errorReader().lines().collect(Collectors.joining("\n"));
-        System.out.println("Error Stream: >>>\n" + result + "\n<<<");
+		project = Utils.provisionTestProject("vue-app");
+		ProcessBuilder builder = NodeJSManager.prepareNPMProcessBuilder("install", "--no-bin-links", "--ignore-scripts")
+				.directory(project.getLocation().toFile());
+		Process process = builder.start();
+		System.out.println(builder.command().toString());
+		String result = process.errorReader().lines().collect(Collectors.joining("\n"));
+		System.out.println("Error Stream: >>>\n" + result + "\n<<<");
 
-        result = process.inputReader().lines().collect(Collectors.joining("\n"));
-        System.out.println("Output Stream: >>>\n" + result + "\n<<<");
+		result = process.inputReader().lines().collect(Collectors.joining("\n"));
+		System.out.println("Output Stream: >>>\n" + result + "\n<<<");
 
-        assertEquals(0, process.waitFor(), "npm install didn't complete property");
+		assertEquals(0, process.waitFor(), "npm install didn't complete property");
 
-        project.refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
-        assertTrue(project.exists());
-        componentFolder = project.getFolder("src").getFolder("components");
-        assertTrue(componentFolder.exists());
-    }
+		project.refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
+		assertTrue(project.exists());
+		componentFolder = project.getFolder("src").getFolder("components");
+		assertTrue(componentFolder.exists());
+	}
 
-    @BeforeEach
-    public void setUpTestCase() {
-        AllCleanRule.enableLogging();
-    }
+	@BeforeEach
+	public void setUpTestCase() {
+		AllCleanRule.enableLogging();
+	}
 
-    @AfterAll
-    public static void tearDown() throws Exception {
-        new AllCleanRule().afterEach(null);
-    }
+	@AfterAll
+	public static void tearDown() throws Exception {
+		new AllCleanRule().afterEach(null);
+	}
 
-    @Test
-    void testVueApp() throws Exception {
-        IFile appComponentFile = project.getFile("src/App.vue");
-        TextEditor editor = (TextEditor) IDE
-                .openEditor(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), appComponentFile);
-        LanguageServerWrapper lsWrapper = LanguageServiceAccessor.getLSWrapper(project,
-                LanguageServersRegistry.getInstance().getDefinition("org.eclipse.wildwebdeveloper.vue"));
+	@Test
+	void testVueApp() throws Exception {
+		IFile appComponentFile = project.getFile("src/App.vue");
+		TextEditor editor = (TextEditor) IDE
+				.openEditor(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), appComponentFile);
+		LanguageServerWrapper lsWrapper = LanguageServiceAccessor.getLSWrapper(project,
+				LanguageServersRegistry.getInstance().getDefinition("org.eclipse.wildwebdeveloper.vue"));
 
-        assertTrue(DisplayHelper.waitForCondition(editor.getSite().getShell().getDisplay(), 30000, () -> {
-            try {
-                return Arrays
-                        .stream(appComponentFile.findMarkers("org.eclipse.lsp4e.diagnostic", true,
-                                IResource.DEPTH_ZERO))
-                        .anyMatch(marker -> marker.getAttribute(IMarker.MESSAGE, "").contains("never read"));
-            } catch (CoreException e) {
-                e.printStackTrace();
-                return false;
-            }
-        }),
-                "Diagnostic not published in standalone component file");
-        IDocument document = editor.getDocumentProvider().getDocument(editor.getEditorInput());
-        assertTrue(DisplayHelper.waitForCondition(editor.getSite().getShell().getDisplay(), 30000,
-                () -> lsWrapper.isActive() && lsWrapper.isConnectedTo(LSPEclipseUtils.toUri(document))
-                        && lsWrapper.canOperate(project) && lsWrapper.canOperate(document)));
-        LSContentAssistProcessor contentAssistProcessor = new LSContentAssistProcessor();
-        ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(Utils.getViewer(editor),
-                document.get().indexOf(" }}"));
-        Optional<ICompletionProposal> proposal = Arrays.stream(proposals)
-                .filter(item -> item.getDisplayString().equals("appParameter")).findFirst();
+		assertTrue(DisplayHelper.waitForCondition(editor.getSite().getShell().getDisplay(), 30000, () -> {
+			try {
+				return Arrays
+						.stream(appComponentFile.findMarkers("org.eclipse.lsp4e.diagnostic", true,
+								IResource.DEPTH_ZERO))
+						.anyMatch(marker -> marker.getAttribute(IMarker.MESSAGE, "").contains("never read"));
+			} catch (CoreException e) {
+				e.printStackTrace();
+				return false;
+			}
+		}), "Diagnostic not published in standalone component file");
+		IDocument document = editor.getDocumentProvider().getDocument(editor.getEditorInput());
+		assertTrue(DisplayHelper.waitForCondition(editor.getSite().getShell().getDisplay(), 30000,
+				() -> lsWrapper.isActive() && lsWrapper.isConnectedTo(LSPEclipseUtils.toUri(document))
+						&& lsWrapper.canOperate(project) && lsWrapper.canOperate(document)));
+		LSContentAssistProcessor contentAssistProcessor = new LSContentAssistProcessor();
+		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(Utils.getViewer(editor),
+				document.get().indexOf(" }}"));
+		Optional<ICompletionProposal> proposal = Arrays.stream(proposals)
+				.filter(item -> item.getDisplayString().equals("appParameter")).findFirst();
 
-        assertTrue(proposal.isPresent(), "Proposal not exists");
-        proposal.get().apply(document);
+		assertTrue(proposal.isPresent(), "Proposal not exists");
+		proposal.get().apply(document);
 
-        assertTrue(document.get().contains("{{ this.appParameter }}"), "Incorrect completion insertion");
+		assertTrue(document.get().contains("{{ this.appParameter }}"), "Incorrect completion insertion");
 
-        editor.close(false);
-    }
+		editor.close(false);
+	}
 
-    @Test
-    void testVueTemplate() throws Exception {
-        TextEditor editor = (TextEditor) IDE.openEditor(
-                PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(),
-                componentFolder.getFile("HelloWorld.vue"));
-        LanguageServerWrapper lsWrapper = LanguageServiceAccessor.getLSWrapper(project,
-                LanguageServersRegistry.getInstance().getDefinition("org.eclipse.wildwebdeveloper.vue"));
-        IFile appComponentHTML = componentFolder.getFile("HelloWorld.vue");
-        editor = (TextEditor) IDE.openEditor(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(),
-                appComponentHTML);
-        IDocument document = editor.getDocumentProvider().getDocument(editor.getEditorInput());
-        String tagName = "only-start";
-        String tag = '<' + tagName + '>';
-        document.set(document.get().replace(tag, tag + "<"));
-        assertTrue(DisplayHelper.waitForCondition(editor.getSite().getShell().getDisplay(), 30000, () -> {
-            IMarker[] markers;
-            try {
-                markers = appComponentHTML.findMarkers("org.eclipse.lsp4e.diagnostic", true, IResource.DEPTH_ZERO);
-                return Arrays.stream(markers).anyMatch(
-                        marker -> marker.getAttribute(IMarker.MESSAGE, "").contains("Element is missing end tag."));
-            } catch (CoreException e) {
-                e.printStackTrace();
-                return false;
-            }
-        }),
-                "No error found on erroneous HTML component file");
+	@Test
+	void testVueTemplate() throws Exception {
+		TextEditor editor = (TextEditor) IDE.openEditor(
+				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(),
+				componentFolder.getFile("HelloWorld.vue"));
+		LanguageServerWrapper lsWrapper = LanguageServiceAccessor.getLSWrapper(project,
+				LanguageServersRegistry.getInstance().getDefinition("org.eclipse.wildwebdeveloper.vue"));
+		IFile appComponentHTML = componentFolder.getFile("HelloWorld.vue");
+		editor = (TextEditor) IDE.openEditor(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(),
+				appComponentHTML);
+		IDocument document = editor.getDocumentProvider().getDocument(editor.getEditorInput());
+		String tagName = "only-start";
+		String tag = '<' + tagName + '>';
+		document.set(document.get().replace(tag, tag + "<"));
+		assertTrue(DisplayHelper.waitForCondition(editor.getSite().getShell().getDisplay(), 30000, () -> {
+			IMarker[] markers;
+			try {
+				markers = appComponentHTML.findMarkers("org.eclipse.lsp4e.diagnostic", true, IResource.DEPTH_ZERO);
+				return Arrays.stream(markers).anyMatch(
+						marker -> marker.getAttribute(IMarker.MESSAGE, "").contains("Element is missing end tag."));
+			} catch (CoreException e) {
+				e.printStackTrace();
+				return false;
+			}
+		}), "No error found on erroneous HTML component file");
 
-        assertTrue(DisplayHelper.waitForCondition(editor.getSite().getShell().getDisplay(), 30000,
-                () -> lsWrapper.isActive() && lsWrapper.isConnectedTo(LSPEclipseUtils.toUri(document))
-                        && lsWrapper.canOperate(project) && lsWrapper.canOperate(document)));
+		assertTrue(DisplayHelper.waitForCondition(editor.getSite().getShell().getDisplay(), 30000,
+				() -> lsWrapper.isActive() && lsWrapper.isConnectedTo(LSPEclipseUtils.toUri(document))
+						&& lsWrapper.canOperate(project) && lsWrapper.canOperate(document)));
 
-        LSContentAssistProcessor contentAssistProcessor = new LSContentAssistProcessor();
+		LSContentAssistProcessor contentAssistProcessor = new LSContentAssistProcessor();
 
-        int pos = document.get().indexOf(tag) + tag.length();
-        ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(Utils.getViewer(editor),
-                pos + 1);
+		int pos = document.get().indexOf(tag) + tag.length();
+		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(Utils.getViewer(editor),
+				pos + 1);
 
-        // Find closing tag proposal
-        ICompletionProposal closingTagProposal = Arrays.stream(proposals)
-                .filter(p -> p.getDisplayString().equals('/' + tagName)).findFirst().orElse(null);
-        assertNotNull(closingTagProposal, "Closing tag proposal not found for '" + tag + "'");
+		System.out.println("TestVue.testVueTemplate$ Position: " + pos + " [..."
+				+ document.get().substring(pos - 3, pos) + "|" + document.get().substring(pos, pos + 3) + "...]");
 
-        closingTagProposal.apply(document);
-        assertEquals(new String(componentFolder.getFile("HelloWorldCorrect.vue").getContents().readAllBytes()).trim(),
-                document.get().trim(), "Incorrect completion insertion");
+		System.out.println("TestVue.testVueTemplate$ >>> proposals >>>");
+		for (ICompletionProposal p : proposals) {
+			System.out.println("TestVue.testVueTemplate$\tproposal: " + p.getDisplayString());
+		}
+		System.out.println("TestVue.testVueTemplate$ <<< proposals <<<");
 
-        editor.close(false);
-    }
+		// Find closing tag proposal
+		ICompletionProposal closingTagProposal = Arrays.stream(proposals)
+				.filter(p -> p.getDisplayString().equals('/' + tagName)).findFirst().orElse(null);
+		assertNotNull(closingTagProposal, "Closing tag proposal not found for '" + tag + "'");
+
+		closingTagProposal.apply(document);
+		assertEquals(new String(componentFolder.getFile("HelloWorldCorrect.vue").getContents().readAllBytes()).trim(),
+				document.get().trim(), "Incorrect completion insertion");
+
+		editor.close(false);
+	}
 }


### PR DESCRIPTION
```
Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 20.24 s <<< FAILURE! -- in org.eclipse.wildwebdeveloper.tests.TestVue
org.eclipse.wildwebdeveloper.tests.TestVue.testVueTemplate -- Time elapsed: 3.268 s <<< FAILURE!
org.opentest4j.AssertionFailedError: Closing tag proposal not found for '<only-start>' ==> expected: not <null>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:152)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertNotNull.failNull(AssertNotNull.java:49)
	at org.junit.jupiter.api.AssertNotNull.assertNotNull(AssertNotNull.java:35)
	at org.junit.jupiter.api.Assertions.assertNotNull(Assertions.java:312)
	at org.eclipse.wildwebdeveloper.tests.TestVue.testVueTemplate(TestVue.java:163)
```