### PR TITLE
Remove irrelevant mention of VSCode in CSS prefs

### DIFF
--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/css/ui/messages.properties
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/css/ui/messages.properties
@@ -17,7 +17,7 @@ ValidPropertiesFieldEditor_inputDialog_description=Fill a property that is not v
 # ****************************** CSS *************************************/
 
 # Completion page
-CSSCompletionPreferencePage_completion_triggerPropertyValueCompletion=By default, VS Code triggers property value completion after selecting a CSS property.\nUse this setting to disable this behavior.
+CSSCompletionPreferencePage_completion_triggerPropertyValueCompletion=Trigger property value completion after selecting a property.
 CSSCompletionPreferencePage_completion_completePropertyWithSemicolon=Insert semicolon at end of line when completing CSS properties.
 
 # Format page
@@ -60,7 +60,7 @@ CSSValidationPreferencePage_lint_unknownAtRules=Unknown at-rule.
 # ****************************** LESS *************************************/
 
 # Completion page
-LESSCompletionPreferencePage_completion_triggerPropertyValueCompletion=By default, VS Code triggers property value completion after selecting a LESS property.\nUse this setting to disable this behavior.
+LESSCompletionPreferencePage_completion_triggerPropertyValueCompletion=Trigger property value completion after selecting a property.
 LESSCompletionPreferencePage_completion_completePropertyWithSemicolon=Insert semicolon at end of line when completing LESS properties.
 
 # Format page
@@ -103,7 +103,7 @@ LESSValidationPreferencePage_lint_unknownAtRules=Unknown at-rule.
 # ****************************** SCSS *************************************/
 
 # Completion page
-SCSSCompletionPreferencePage_completion_triggerPropertyValueCompletion=By default, VS Code triggers property value completion after selecting a SCSS property.\nUse this setting to disable this behavior.
+SCSSCompletionPreferencePage_completion_triggerPropertyValueCompletion=Trigger property value completion after selecting a property.
 SCSSCompletionPreferencePage_completion_completePropertyWithSemicolon=Insert semicolon at end of line when completing SCSS properties.
 
 # Format page


### PR DESCRIPTION
Fixes https://github.com/eclipse-wildwebdeveloper/wildwebdeveloper/issues/1813