### PR TITLE
fix: NPE in AbstractDebugAdapterLaunchShortcut.canLaunch

### DIFF
--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/AbstractDebugAdapterLaunchShortcut.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/AbstractDebugAdapterLaunchShortcut.java
@@ -64,7 +64,7 @@ public abstract class AbstractDebugAdapterLaunchShortcut implements ILaunchShort
 	public boolean canLaunch(File file) {
 		return file.exists() &&
 			Arrays.stream(contentTypeIds).map(Platform.getContentTypeManager()::getContentType)
-				.anyMatch(type -> type.isAssociatedWith(file.getName()));
+				.anyMatch(type -> type != null && type.isAssociatedWith(file.getName()));
 	}
 
 	public boolean canLaunchResource(IResource resource) {


### PR DESCRIPTION
This PR addresses this logged exception. I do not know what triggers it but adding a null check avoids the NPE.

```py
!ENTRY org.eclipse.debug.ui 4 0 2025-06-02 12:38:12.704
!MESSAGE Launch shortcut 'org.eclipse.wildwebdeveloper.chromeRunShortcut' enablement expression caused exception. Shortcut was removed.
!STACK 1
org.eclipse.core.runtime.CoreException: Error evaluating Property [org.eclipse.wildwebdeveloper.isHTMLLaunchable, type=class org.eclipse.core.internal.resources.File, tester=org.eclipse.wildwebdeveloper.debug.IsLaunchableHTMLTester@314c71d7]
	at org.eclipse.core.internal.expressions.Property.test(Property.java:68)
	at org.eclipse.core.expressions.TestExpression.evaluate(TestExpression.java:107)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.internal.expressions.AdaptExpression.evaluate(AdaptExpression.java:121)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.internal.expressions.IterateExpression.evaluate(IterateExpression.java:163)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.expressions.WithExpression.evaluate(WithExpression.java:84)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.internal.expressions.EnablementExpression.evaluate(EnablementExpression.java:59)
	at org.eclipse.debug.internal.ui.launchConfigurations.LaunchShortcutExtension.evalEnablementExpression(LaunchShortcutExtension.java:273)
	at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationManager.getApplicableConfigurationTypes(LaunchConfigurationManager.java:727)
	at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationManager.getApplicableLaunchConfigurations(LaunchConfigurationManager.java:765)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager.getParticipatingLaunchConfigurations(LaunchingResourceManager.java:519)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager.getLabel(LaunchingResourceManager.java:338)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager.computeLabels(LaunchingResourceManager.java:258)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager$1$1.run(LaunchingResourceManager.java:147)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
Caused by: java.lang.NullPointerException: Cannot invoke "org.eclipse.core.runtime.content.IContentType.isAssociatedWith(String)" because "type" is null
	at org.eclipse.wildwebdeveloper.debug.AbstractDebugAdapterLaunchShortcut.lambda$1(AbstractDebugAdapterLaunchShortcut.java:67)
	at java.base/java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:1034)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:632)
	at org.eclipse.wildwebdeveloper.debug.AbstractDebugAdapterLaunchShortcut.canLaunch(AbstractDebugAdapterLaunchShortcut.java:67)
	at org.eclipse.wildwebdeveloper.debug.AbstractDebugAdapterLaunchShortcut.canLaunchResource(AbstractDebugAdapterLaunchShortcut.java:74)
	at org.eclipse.wildwebdeveloper.debug.AbstractHTMLDebugAdapterLaunchShortcut.canLaunchResource(AbstractHTMLDebugAdapterLaunchShortcut.java:28)
	at org.eclipse.wildwebdeveloper.debug.IsLaunchableHTMLTester.test(IsLaunchableHTMLTester.java:29)
	at org.eclipse.core.internal.expressions.Property.test(Property.java:65)
	... 17 more
!SUBENTRY 1 org.eclipse.core.expressions 4 0 2025-06-02 12:38:12.705
!MESSAGE Error evaluating Property [org.eclipse.wildwebdeveloper.isHTMLLaunchable, type=class org.eclipse.core.internal.resources.File, tester=org.eclipse.wildwebdeveloper.debug.IsLaunchableHTMLTester@314c71d7]
!STACK 0
java.lang.NullPointerException: Cannot invoke "org.eclipse.core.runtime.content.IContentType.isAssociatedWith(String)" because "type" is null
	at org.eclipse.wildwebdeveloper.debug.AbstractDebugAdapterLaunchShortcut.lambda$1(AbstractDebugAdapterLaunchShortcut.java:67)
	at java.base/java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:1034)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:632)
	at org.eclipse.wildwebdeveloper.debug.AbstractDebugAdapterLaunchShortcut.canLaunch(AbstractDebugAdapterLaunchShortcut.java:67)
	at org.eclipse.wildwebdeveloper.debug.AbstractDebugAdapterLaunchShortcut.canLaunchResource(AbstractDebugAdapterLaunchShortcut.java:74)
	at org.eclipse.wildwebdeveloper.debug.AbstractHTMLDebugAdapterLaunchShortcut.canLaunchResource(AbstractHTMLDebugAdapterLaunchShortcut.java:28)
	at org.eclipse.wildwebdeveloper.debug.IsLaunchableHTMLTester.test(IsLaunchableHTMLTester.java:29)
	at org.eclipse.core.internal.expressions.Property.test(Property.java:65)
	at org.eclipse.core.expressions.TestExpression.evaluate(TestExpression.java:107)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.internal.expressions.AdaptExpression.evaluate(AdaptExpression.java:121)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.internal.expressions.IterateExpression.evaluate(IterateExpression.java:163)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.expressions.WithExpression.evaluate(WithExpression.java:84)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.internal.expressions.EnablementExpression.evaluate(EnablementExpression.java:59)
	at org.eclipse.debug.internal.ui.launchConfigurations.LaunchShortcutExtension.evalEnablementExpression(LaunchShortcutExtension.java:273)
	at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationManager.getApplicableConfigurationTypes(LaunchConfigurationManager.java:727)
	at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationManager.getApplicableLaunchConfigurations(LaunchConfigurationManager.java:765)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager.getParticipatingLaunchConfigurations(LaunchingResourceManager.java:519)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager.getLabel(LaunchingResourceManager.java:338)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager.computeLabels(LaunchingResourceManager.java:258)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager$1$1.run(LaunchingResourceManager.java:147)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)

!ENTRY org.eclipse.debug.ui 4 0 2025-06-02 12:38:12.706
!MESSAGE Launch shortcut 'org.eclipse.wildwebdeveloper.firefoxRunShortcut' enablement expression caused exception. Shortcut was removed.
!STACK 1
org.eclipse.core.runtime.CoreException: Error evaluating Property [org.eclipse.wildwebdeveloper.isHTMLLaunchable, type=class org.eclipse.core.internal.resources.File, tester=org.eclipse.wildwebdeveloper.debug.IsLaunchableHTMLTester@314c71d7]
	at org.eclipse.core.internal.expressions.Property.test(Property.java:68)
	at org.eclipse.core.expressions.TestExpression.evaluate(TestExpression.java:107)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.internal.expressions.AdaptExpression.evaluate(AdaptExpression.java:121)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.internal.expressions.IterateExpression.evaluate(IterateExpression.java:163)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.expressions.WithExpression.evaluate(WithExpression.java:84)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.internal.expressions.EnablementExpression.evaluate(EnablementExpression.java:59)
	at org.eclipse.debug.internal.ui.launchConfigurations.LaunchShortcutExtension.evalEnablementExpression(LaunchShortcutExtension.java:273)
	at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationManager.getApplicableConfigurationTypes(LaunchConfigurationManager.java:727)
	at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationManager.getApplicableLaunchConfigurations(LaunchConfigurationManager.java:765)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager.getParticipatingLaunchConfigurations(LaunchingResourceManager.java:519)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager.getLabel(LaunchingResourceManager.java:338)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager.computeLabels(LaunchingResourceManager.java:258)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager$1$1.run(LaunchingResourceManager.java:147)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
Caused by: java.lang.NullPointerException: Cannot invoke "org.eclipse.core.runtime.content.IContentType.isAssociatedWith(String)" because "type" is null
	at org.eclipse.wildwebdeveloper.debug.AbstractDebugAdapterLaunchShortcut.lambda$1(AbstractDebugAdapterLaunchShortcut.java:67)
	at java.base/java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:1034)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:632)
	at org.eclipse.wildwebdeveloper.debug.AbstractDebugAdapterLaunchShortcut.canLaunch(AbstractDebugAdapterLaunchShortcut.java:67)
	at org.eclipse.wildwebdeveloper.debug.AbstractDebugAdapterLaunchShortcut.canLaunchResource(AbstractDebugAdapterLaunchShortcut.java:74)
	at org.eclipse.wildwebdeveloper.debug.AbstractHTMLDebugAdapterLaunchShortcut.canLaunchResource(AbstractHTMLDebugAdapterLaunchShortcut.java:28)
	at org.eclipse.wildwebdeveloper.debug.IsLaunchableHTMLTester.test(IsLaunchableHTMLTester.java:29)
	at org.eclipse.core.internal.expressions.Property.test(Property.java:65)
	... 17 more
!SUBENTRY 1 org.eclipse.core.expressions 4 0 2025-06-02 12:38:12.707
!MESSAGE Error evaluating Property [org.eclipse.wildwebdeveloper.isHTMLLaunchable, type=class org.eclipse.core.internal.resources.File, tester=org.eclipse.wildwebdeveloper.debug.IsLaunchableHTMLTester@314c71d7]
!STACK 0
java.lang.NullPointerException: Cannot invoke "org.eclipse.core.runtime.content.IContentType.isAssociatedWith(String)" because "type" is null
	at org.eclipse.wildwebdeveloper.debug.AbstractDebugAdapterLaunchShortcut.lambda$1(AbstractDebugAdapterLaunchShortcut.java:67)
	at java.base/java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:1034)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:632)
	at org.eclipse.wildwebdeveloper.debug.AbstractDebugAdapterLaunchShortcut.canLaunch(AbstractDebugAdapterLaunchShortcut.java:67)
	at org.eclipse.wildwebdeveloper.debug.AbstractDebugAdapterLaunchShortcut.canLaunchResource(AbstractDebugAdapterLaunchShortcut.java:74)
	at org.eclipse.wildwebdeveloper.debug.AbstractHTMLDebugAdapterLaunchShortcut.canLaunchResource(AbstractHTMLDebugAdapterLaunchShortcut.java:28)
	at org.eclipse.wildwebdeveloper.debug.IsLaunchableHTMLTester.test(IsLaunchableHTMLTester.java:29)
	at org.eclipse.core.internal.expressions.Property.test(Property.java:65)
	at org.eclipse.core.expressions.TestExpression.evaluate(TestExpression.java:107)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.internal.expressions.AdaptExpression.evaluate(AdaptExpression.java:121)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.internal.expressions.IterateExpression.evaluate(IterateExpression.java:163)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.expressions.WithExpression.evaluate(WithExpression.java:84)
	at org.eclipse.core.expressions.CompositeExpression.evaluateAnd(CompositeExpression.java:54)
	at org.eclipse.core.internal.expressions.EnablementExpression.evaluate(EnablementExpression.java:59)
	at org.eclipse.debug.internal.ui.launchConfigurations.LaunchShortcutExtension.evalEnablementExpression(LaunchShortcutExtension.java:273)
	at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationManager.getApplicableConfigurationTypes(LaunchConfigurationManager.java:727)
	at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationManager.getApplicableLaunchConfigurations(LaunchConfigurationManager.java:765)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager.getParticipatingLaunchConfigurations(LaunchingResourceManager.java:519)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager.getLabel(LaunchingResourceManager.java:338)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager.computeLabels(LaunchingResourceManager.java:258)
	at org.eclipse.debug.internal.ui.contextlaunching.LaunchingResourceManager$1$1.run(LaunchingResourceManager.java:147)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)

```