### PR TITLE
Fix license check artifact upload error

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -131,7 +131,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: always() && env.request-review
       with:
-        name: 'tools.wildwebdeveloper-license-vetting-summary'
+        name: tools.wildwebdeveloper-license-vetting-summary-${{ github.run_id }}
         path: |
           target/dash/npm-review-summary
           target/dash/summary


### PR DESCRIPTION
When re-starting the license check jobs, it may result into the following failure:
```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```