### PR TITLE
ci: don't run license check if dependencies don't change

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -1,20 +1,32 @@
-# This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-
+# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
 name: License check
 
-on:
+on:  # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows
   push:
     branches: 
       - 'master'
+    paths:
+    - '**/package.json'
+    - '**/package-lock.json'
+    - '**/pom.xml'
+    - '**/*.target'
   pull_request:
     branches: 
      - 'master'
+    paths:
+    - '**/package.json'
+    - '**/package-lock.json'
+    - '**/pom.xml'
+    - '**/*.target'
   issue_comment:
     types: [created]
-    
+  workflow_dispatch:
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch
+
 jobs:
+  ###########################################################
   call-mvn-license-check:
+  ###########################################################
     uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
     with:
       projectId: tools.wildwebdeveloper
@@ -23,7 +35,10 @@ jobs:
       gitlabAPIToken: ${{ secrets.GITLAB_API_TOKEN }}
     permissions:
       pull-requests: write
+
+  ###########################################################
   npm-check:
+  ###########################################################
     if: github.event_name != 'issue_comment' || ( github.event.issue.pull_request != '' && (github.event.comment.body == '/request-license-review') )
     # Run on all non-comment events specified by the calling workflow and for comments on PRs that have a corresponding body.
     runs-on: ubuntu-latest


### PR DESCRIPTION
This avoids unnecessary calls to the ClearlyDefined API which constantly fails with rate limit errors.