### PR TITLE
fix(markdown): avoid workspace-wide diagnostics refresh thread pileup

### DIFF
--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/markdown/MarkdownDiagnosticsManager.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/markdown/MarkdownDiagnosticsManager.java
@@ -13,9 +13,15 @@
 package org.eclipse.wildwebdeveloper.markdown;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.IFileBuffer;
@@ -28,6 +34,15 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.content.IContentType;
+import org.eclipse.core.runtime.content.IContentTypeManager;
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LanguageServers;
@@ -49,7 +64,77 @@ import org.eclipse.lsp4j.services.LanguageServer;
  */
 public final class MarkdownDiagnosticsManager {
 
+	private static final String MARKDOWN_CONTENT_TYPE_ID = "org.eclipse.tm4e.language_pack.markdown";
 	public static final String MARKDOWN_MARKER_TYPE = "org.eclipse.wildwebdeveloper.markdown.problem";
+
+	private static final long REFRESH_DEBOUNCE_MS = 250;
+	private static final long DIAGNOSTICS_TIMEOUT_SECONDS = 30;
+
+	private static final Set<IFile> OPEN_MARKDOWN_FILES = ConcurrentHashMap.newKeySet();
+
+	/** De-dupes diagnostic pulls so repeated refresh requests do not start overlapping diagnostics for the same file/server */
+	private static final ConcurrentHashMap<String, CompletableFuture<Void>> IN_FLIGHT_REFRESHES = new ConcurrentHashMap<>();
+
+	/** Servers that requested a refresh since the last debounce run (identity-based: some LS proxies do not implement hashCode()) */
+	private static final Set<LanguageServer> PENDING_REFRESH_SERVERS = Collections.newSetFromMap(new IdentityHashMap<>());
+
+	/** Debounced, serialized refresh runner (avoids a thread pileup when multiple refreshes are requested in quick succession) */
+	private static Job REFRESH_JOB;
+
+	/** Guards access to REFRESH_JOB and the pending refresh bookkeeping below */
+	private static final Object REFRESH_JOB_LOCK = new Object();
+
+	/** Set when a refresh is requested while the job is running (rescheduled in the job-complete listener) */
+	private static boolean REFRESH_RESCHEDULE_REQUESTED;
+
+	private static boolean isMarkdownFile(final IFile file) {
+		if (file == null)
+			return false;
+		try {
+			final IContentTypeManager ctm = Platform.getContentTypeManager();
+			final IContentType markdownCT = ctm.getContentType(MARKDOWN_CONTENT_TYPE_ID);
+			if (markdownCT != null) {
+				final IContentType fileCT = ctm.findContentTypeFor(file.getName());
+				if (fileCT != null && fileCT.isKindOf(markdownCT))
+					return true;
+			}
+		} catch (final Exception ex) {
+			ILog.get().warn(ex.getMessage(), ex);
+		}
+
+		// Fallback: cheap extension check (and keeps behavior if TM4E is absent / not initialized)
+		final String ext = file.getFileExtension();
+		if (ext == null)
+			return false;
+		return switch (ext.toLowerCase(Locale.ROOT)) {
+			case "md", "markdown", "mdown" -> true;
+			default -> false;
+		};
+	}
+
+	private static IFile toWorkspaceFile(final IPath location) {
+		if (location == null)
+			return null;
+
+		final var root = ResourcesPlugin.getWorkspace().getRoot();
+		final IResource res = root.findMember(location);
+		if (res instanceof final IFile file)
+			return file;
+		return root.getFileForLocation(location);
+	}
+
+	private static List<IFile> snapshotOpenMarkdownFiles() {
+		if (OPEN_MARKDOWN_FILES.isEmpty())
+			return List.of();
+
+		final var out = new ArrayList<IFile>(OPEN_MARKDOWN_FILES.size());
+		for (final IFile file : OPEN_MARKDOWN_FILES) {
+			if (file != null && file.exists() && isMarkdownFile(file)) {
+				out.add(file);
+			}
+		}
+		return out;
+	}
 
 	static {
 		// Remove problem markers when a Markdown text buffer is disposed (editor closed)
@@ -66,7 +151,15 @@ public final class MarkdownDiagnosticsManager {
 
 			@Override
 			public void bufferCreated(final IFileBuffer buffer) {
-				// no-op
+				try {
+					final IPath location = buffer.getLocation();
+					final IFile file = toWorkspaceFile(location);
+					if (file != null && file.exists() && isMarkdownFile(file)) {
+						OPEN_MARKDOWN_FILES.add(file);
+					}
+				} catch (final Exception ex) {
+					ILog.get().warn(ex.getMessage(), ex);
+				}
 			}
 
 			@Override
@@ -75,18 +168,17 @@ public final class MarkdownDiagnosticsManager {
 				if (location == null)
 					return;
 
-				/*
-				 * remove all problem markers on editor close
-				 */
 				try {
-					final var root = ResourcesPlugin.getWorkspace().getRoot();
-					final var res = root.findMember(location);
-					if (res instanceof final IFile file && file.exists()) {
-						final String name = file.getName().toLowerCase();
-						if (name.endsWith(".md") || name.endsWith(".markdown") || name.endsWith(".mdown")) {
-							clearMarkers(file);
-						}
-					}
+					final IFile file = toWorkspaceFile(location);
+					if (file == null || !file.exists() || !isMarkdownFile(file))
+						return;
+
+					OPEN_MARKDOWN_FILES.remove(file);
+
+					/*
+					 * remove all problem markers on editor close
+					 */
+					clearMarkers(file);
 				} catch (Exception ex) {
 					ILog.get().warn(ex.getMessage(), ex);
 				}
@@ -119,7 +211,18 @@ public final class MarkdownDiagnosticsManager {
 
 			@Override
 			public void underlyingFileMoved(final IFileBuffer buffer, IPath path) {
-				// no-op
+				try {
+					final IFile newFile = toWorkspaceFile(buffer.getLocation());
+					final IFile otherFile = toWorkspaceFile(path);
+					if (newFile != null)
+						OPEN_MARKDOWN_FILES.remove(newFile);
+					if (otherFile != null)
+						OPEN_MARKDOWN_FILES.remove(otherFile);
+					if (newFile != null && newFile.exists() && isMarkdownFile(newFile))
+						OPEN_MARKDOWN_FILES.add(newFile);
+				} catch (final Exception ex) {
+					ILog.get().warn(ex.getMessage(), ex);
+				}
 			}
 
 		});
@@ -192,49 +295,123 @@ public final class MarkdownDiagnosticsManager {
 		file.deleteMarkers(MARKDOWN_MARKER_TYPE, true, IResource.DEPTH_ZERO);
 	}
 
-	private static List<Diagnostic> extractDiagnostics(final DocumentDiagnosticReport report) {
-		if (report == null)
+	private static List<Diagnostic> extractDiagnostics(final RelatedFullDocumentDiagnosticReport full) {
+		if (full == null)
 			return List.of();
+
+		final var out = new ArrayList<Diagnostic>();
+		if (full.getItems() != null)
+			out.addAll(full.getItems());
+		if (full.getRelatedDocuments() != null) {
+			for (final Either<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport> rel : full.getRelatedDocuments().values()) {
+				if (rel != null && rel.isLeft()) {
+					final FullDocumentDiagnosticReport rfull = rel.getLeft();
+					if (rfull.getItems() != null) {
+						out.addAll(rfull.getItems());
+					}
+				}
+				// if rel.isRight() -> unchanged for that related doc: ignore
+			}
+		}
+		return out;
+	}
+
+	private static void handleDiagnosticReport(final IFile file, final DocumentDiagnosticReport report) {
+		if (file == null || !file.exists() || report == null)
+			return;
+
+		if (report.isRight()) {
+			// Unchanged for the main document: do not touch markers
+			return;
+		}
+
 		if (report.isLeft()) {
-			final RelatedFullDocumentDiagnosticReport full = report.getLeft();
-			final var out = new ArrayList<Diagnostic>();
-			if (full.getItems() != null)
-				out.addAll(full.getItems());
-			if (full.getRelatedDocuments() != null) {
-				for (final Either<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport> rel : full.getRelatedDocuments()
-						.values()) {
-					if (rel != null && rel.isLeft()) {
-						final FullDocumentDiagnosticReport rfull = rel.getLeft();
-						if (rfull.getItems() != null) {
-							out.addAll(rfull.getItems());
+			applyMarkers(file, extractDiagnostics(report.getLeft()));
+		}
+	}
+
+	private static void scheduleRefreshAllOpenMarkdownFiles(final LanguageServer languageServer) {
+		if (languageServer == null)
+			return;
+
+		synchronized (REFRESH_JOB_LOCK) {
+			PENDING_REFRESH_SERVERS.add(languageServer);
+			if (REFRESH_JOB == null) {
+				REFRESH_JOB = new Job("Wild Web Developer Markdown diagnostics refresh") {
+					@Override
+					protected IStatus run(final IProgressMonitor monitor) {
+						final List<LanguageServer> languageServersToRefresh;
+						synchronized (REFRESH_JOB_LOCK) {
+							if (PENDING_REFRESH_SERVERS.isEmpty())
+								return Status.OK_STATUS;
+							languageServersToRefresh = new ArrayList<>(PENDING_REFRESH_SERVERS);
+							PENDING_REFRESH_SERVERS.clear();
+						}
+
+						if (monitor.isCanceled())
+							return Status.OK_STATUS;
+
+						final List<IFile> openFiles = snapshotOpenMarkdownFiles();
+						if (openFiles.isEmpty())
+							return Status.OK_STATUS;
+
+						for (final LanguageServer ls : languageServersToRefresh) {
+							if (monitor.isCanceled())
+								break;
+							for (final IFile file : openFiles) {
+								if (monitor.isCanceled())
+									break;
+								refreshFile(file, ls);
+							}
+						}
+						return Status.OK_STATUS;
+					}
+				};
+				REFRESH_JOB.setSystem(true);
+				REFRESH_JOB.addJobChangeListener(new JobChangeAdapter() {
+					@Override
+					public void done(final IJobChangeEvent event) {
+						synchronized (REFRESH_JOB_LOCK) {
+							if (!REFRESH_RESCHEDULE_REQUESTED && PENDING_REFRESH_SERVERS.isEmpty())
+								return;
+							REFRESH_RESCHEDULE_REQUESTED = false;
+
+							if (REFRESH_JOB == null || REFRESH_JOB.getState() != Job.NONE) {
+								REFRESH_RESCHEDULE_REQUESTED = true;
+								return;
+							}
+
+							try {
+								REFRESH_JOB.schedule(REFRESH_DEBOUNCE_MS);
+							} catch (final IllegalStateException ex) {
+								// Job got scheduled concurrently, try again when it completes.
+								REFRESH_RESCHEDULE_REQUESTED = true;
+							}
 						}
 					}
-					// if rel.isRight() -> unchanged for that related doc: ignore
-				}
+				});
 			}
-			return out;
-		} else if (report.isRight()) {
-			// Unchanged for the main document: do not touch markers
+
+			// Debounce: keep only the latest refresh request.
+			//
+			// Avoid (re-)scheduling while RUNNING; schedule() would throw IllegalStateException.
+			// Instead, mark pending and let the JobChangeListener reschedule once it completes.
+			if (REFRESH_JOB.getState() == Job.RUNNING) {
+				REFRESH_RESCHEDULE_REQUESTED = true;
+				return;
+			}
+
+			try {
+				REFRESH_JOB.cancel();
+				REFRESH_JOB.schedule(REFRESH_DEBOUNCE_MS);
+			} catch (final IllegalStateException ex) {
+				REFRESH_RESCHEDULE_REQUESTED = true;
+			}
 		}
-		return List.of();
 	}
 
 	public static void refreshAllOpenMarkdownFiles(final LanguageServer languageServer) {
-		// Collect .md-like files from open workspace editors would be ideal; for simplicity, scan workspace for *.md, *.markdown, *.mdown
-		try {
-			ResourcesPlugin.getWorkspace().getRoot().accept(res -> {
-				if (res.getType() == IResource.FILE) {
-					final String name = res.getName().toLowerCase();
-					if (name.endsWith(".md") || name.endsWith(".markdown") || name.endsWith(".mdown")) {
-						refreshFile((IFile) res, languageServer);
-					}
-					return false;
-				}
-				return true;
-			});
-		} catch (final Exception ex) {
-			ILog.get().warn(ex.getMessage(), ex);
-		}
+		scheduleRefreshAllOpenMarkdownFiles(languageServer);
 	}
 
 	public static void refreshFile(final IFile file) {
@@ -254,18 +431,31 @@ public final class MarkdownDiagnosticsManager {
 	}
 
 	private static void refreshFile(final IFile file, final LanguageServer languageServer) {
-		try {
-			if (file == null || !file.exists())
-				return;
+		if (file == null || !file.exists() || languageServer == null)
+			return;
+
+		// Include language server identity so de-duping does not hide refreshes across different server instances.
+		final String key = file.getFullPath().toString() + "@" + System.identityHashCode(languageServer);
+		IN_FLIGHT_REFRESHES.compute(key, (k, existing) -> {
+			if (existing != null && !existing.isDone())
+				return existing;
 
 			final String uri = toLspFileUri(file);
 			final var params = new DocumentDiagnosticParams();
 			params.setTextDocument(new TextDocumentIdentifier(uri));
-			final DocumentDiagnosticReport report = languageServer.getTextDocumentService().diagnostic(params).get();
-			applyMarkers(file, extractDiagnostics(report));
-		} catch (final Exception ex) {
-			ILog.get().warn(ex.getMessage(), ex);
-		}
+
+			final CompletableFuture<Void> started = languageServer.getTextDocumentService()
+					.diagnostic(params)
+					.orTimeout(DIAGNOSTICS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+					.thenAccept(report -> handleDiagnosticReport(file, report))
+					.exceptionally(ex -> {
+						ILog.get().warn(ex.getMessage(), ex);
+						return null;
+					});
+
+			started.whenComplete((v, ex) -> IN_FLIGHT_REFRESHES.remove(k, started));
+			return started;
+		});
 	}
 
 	private static int toIMarkerSeverity(final DiagnosticSeverity sev) {

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/markdown/MarkdownLanguageClient.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/markdown/MarkdownLanguageClient.java
@@ -183,7 +183,8 @@ public final class MarkdownLanguageClient extends DefaultLanguageClient {
 	// Acknowledge diagnostic refresh requests and trigger a diagnostic pull
 	@Override
 	public CompletableFuture<Void> refreshDiagnostics() {
-		return CompletableFuture.runAsync(() -> MarkdownDiagnosticsManager.refreshAllOpenMarkdownFiles(getLanguageServer()));
+		MarkdownDiagnosticsManager.refreshAllOpenMarkdownFiles(getLanguageServer());
+		return CompletableFuture.completedFuture(null);
 	}
 
 	/**
@@ -240,7 +241,7 @@ public final class MarkdownLanguageClient extends DefaultLanguageClient {
 					final var uri = URI.create((String) params.get("uri"));
 					final var res = LSPEclipseUtils.findResourceFor(uri);
 					if (res instanceof final IFile file) {
-						CompletableFuture.runAsync(() -> MarkdownDiagnosticsManager.refreshFile(file));
+						MarkdownDiagnosticsManager.refreshFile(file);
 					}
 				} catch (final Exception ignore) {
 				}


### PR DESCRIPTION
Refresh diagnostics only for open Markdown buffers and debounce/serialize refresh requests and de-dupe in-flight refreshes. Make diagnostic pull non-blocking with timeout.

---

This solves issue that threads like this are piling up:

```py
"ForkJoinPool.commonPool-worker-262" #7921 [21548] daemon prio=5 os_prio=0 cpu=3781.25ms elapsed=124139.24s tid=0x00000226ec161850 nid=21548 waiting on condition  [0x0000002de7ffe000]
   java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@21.0.9/Native Method)
        - parking to wait for  <0x0000000765001c88> (a java.util.concurrent.CompletableFuture$Signaller)
        at java.util.concurrent.locks.LockSupport.park(java.base@21.0.9/LockSupport.java:221)
        at java.util.concurrent.CompletableFuture$Signaller.block(java.base@21.0.9/CompletableFuture.java:1864)
        at java.util.concurrent.ForkJoinPool.compensatedBlock(java.base@21.0.9/ForkJoinPool.java:3740)
        at java.util.concurrent.ForkJoinPool.managedBlock(java.base@21.0.9/ForkJoinPool.java:3723)
        at java.util.concurrent.CompletableFuture.waitingGet(java.base@21.0.9/CompletableFuture.java:1898)
        at java.util.concurrent.CompletableFuture.get(java.base@21.0.9/CompletableFuture.java:2072)
        at org.eclipse.wildwebdeveloper.markdown.MarkdownDiagnosticsManager.refreshFile(MarkdownDiagnosticsManager.java:264)
        at org.eclipse.wildwebdeveloper.markdown.MarkdownDiagnosticsManager.lambda$0(MarkdownDiagnosticsManager.java:229)
        at org.eclipse.wildwebdeveloper.markdown.MarkdownDiagnosticsManager$$Lambda/0x00000007c1ddeac0.visit(Unknown Source)
        at org.eclipse.core.internal.resources.Resource.lambda$1(Resource.java:156)
        at org.eclipse.core.internal.resources.Resource$$Lambda/0x00000007c0dccd40.visit(Unknown Source)
        at org.eclipse.core.internal.resources.Resource.lambda$0(Resource.java:124)
        at org.eclipse.core.internal.resources.Resource$$Lambda/0x00000007c07c32e8.visitElement(Unknown Source)
        at org.eclipse.core.internal.watson.ElementTreeIterator.doIteration(ElementTreeIterator.java:85)
        at org.eclipse.core.internal.watson.ElementTreeIterator.doIteration(ElementTreeIterator.java:90)
        at org.eclipse.core.internal.watson.ElementTreeIterator.doIteration(ElementTreeIterator.java:90)
        at org.eclipse.core.internal.watson.ElementTreeIterator.doIteration(ElementTreeIterator.java:90)
        at org.eclipse.core.internal.watson.ElementTreeIterator.doIteration(ElementTreeIterator.java:90)
        at org.eclipse.core.internal.watson.ElementTreeIterator.doIteration(ElementTreeIterator.java:90)
        at org.eclipse.core.internal.watson.ElementTreeIterator.doIteration(ElementTreeIterator.java:90)
        at org.eclipse.core.internal.watson.ElementTreeIterator.iterate(ElementTreeIterator.java:129)
        at org.eclipse.core.internal.resources.Resource.accept(Resource.java:133)
        at org.eclipse.core.internal.resources.Resource.accept(Resource.java:92)
        at org.eclipse.core.internal.resources.Resource.accept(Resource.java:156)
        at org.eclipse.core.internal.resources.Resource.accept(Resource.java:144)
        at org.eclipse.wildwebdeveloper.markdown.MarkdownDiagnosticsManager.refreshAllOpenMarkdownFiles(MarkdownDiagnosticsManager.java:225)
        at org.eclipse.wildwebdeveloper.markdown.MarkdownLanguageClient.lambda$1(MarkdownLanguageClient.java:186)
        at org.eclipse.wildwebdeveloper.markdown.MarkdownLanguageClient$$Lambda/0x00000007c1dde3d8.run(Unknown Source)
        at java.util.concurrent.CompletableFuture$AsyncRun.run(java.base@21.0.9/CompletableFuture.java:1804)
        at java.util.concurrent.CompletableFuture$AsyncRun.exec(java.base@21.0.9/CompletableFuture.java:1796)
        at java.util.concurrent.ForkJoinTask.doExec(java.base@21.0.9/ForkJoinTask.java:387)
        at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(java.base@21.0.9/ForkJoinPool.java:1312)
        at java.util.concurrent.ForkJoinPool.scan(java.base@21.0.9/ForkJoinPool.java:1843)
        at java.util.concurrent.ForkJoinPool.runWorker(java.base@21.0.9/ForkJoinPool.java:1808)
        at java.util.concurrent.ForkJoinWorkerThread.run(java.base@21.0.9/ForkJoinWorkerThread.java:188)

   Locked ownable synchronizers:
        - None
```